### PR TITLE
Fixed #24 corrupted profile pictures on Windows

### DIFF
--- a/src/Yowsup/connectionmanager.py
+++ b/src/Yowsup/connectionmanager.py
@@ -35,7 +35,7 @@ import socket
 import hashlib
 import base64
 import sys
-
+from tempfile import gettempdir
 
 
 import traceback
@@ -968,11 +968,11 @@ class ReaderThread(threading.Thread):
 
 
 	def createTmpFile(self, identifier ,data):
-		tmpDir = "/tmp"
+		tmpDir = gettempdir()
 		
 		filename = "%s/wazapp_%i_%s" % (tmpDir, randrange(0,100000) , hashlib.md5(identifier).hexdigest())
 		
-		tmpfile = open(filename, "w")
+		tmpfile = open(filename, "wb")
 		tmpfile.write(data)
 		tmpfile.close()
 


### PR DESCRIPTION
The profile pictures downloaded on Windows were corrupted.
Fixed also the hardcoded temp directory "/tmp"
