### PR TITLE
Fix syntax error in connectionmanager.py

### DIFF
--- a/src/Yowsup/connectionmanager.py
+++ b/src/Yowsup/connectionmanager.py
@@ -1323,7 +1323,7 @@ class ReaderThread(threading.Thread):
 						vcardData = messageNode.getChild("media").getChild("vcard").toString()
 						vcardName = messageNode.getChild("media").getChild("vcard").getAttributeValue("name")
 						
-						if vcardName and not sys.version_info < (3, 0)::
+						if vcardName and not sys.version_info < (3, 0):
 							vcardName = vcardName.encode('latin-1').decode()
 						
 						if vcardData is not None:


### PR DESCRIPTION
There's an erroneous double '::' that resulted in:

```
Traceback (most recent call last):
  File "yowsup-cli", line 33, in <module>
    from Examples.CmdClient import WhatsappCmdClient
  File "/Users/anant/Code/whatsapp/yowsup/src/Examples/CmdClient.py", line 21, in <module>
    from Yowsup.connectionmanager import YowsupConnectionManager
  File "/Users/anant/Code/whatsapp/yowsup/src/Yowsup/connectionmanager.py", line 1326
    if vcardName and not sys.version_info < (3, 0)::
                                                   ^
SyntaxError: invalid syntax
```
