### PR TITLE
Support connect behind proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,15 @@
-# Yowsup 2 [![Build Status](https://travis-ci.org/tgalal/yowsup.svg?branch=master)](https://travis-ci.org/tgalal/yowsup)
+# Yowsup 2 [![Build Status](https://travis-ci.org/dinhoabreu/yowsup.svg?branch=master)](https://travis-ci.org/dinhoabreu/yowsup)
 
-<a href="https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=Z9KKEUVYEY6BN" target="_blank"><img src="https://www.paypalobjects.com/en_US/i/btn/btn_donate_LG.gif" /></a>
+### HTTP Proxy (April 30, 2015)
+
+Yowsup 2.2.78 - Support connection behind proxy
+
+Example:
+```bash
+export http_proxy="http://yourproxy:8080/" # or
+export http_proxy="http://username:password@yourproxy:8080/" # for authenticated proxies
+./yowsup-cli
+```
 
 ## Updates (January 12, 2015)
 
@@ -83,6 +92,27 @@ You need to have installed python headers (from probably python-dev package) and
 python setup.py install
 ```
 Because of a bug with python-dateutil package you might get permission error for some dateutil file called requires.txt when you use yowsup (see [this bug report](https://bugs.launchpad.net/dateutil/+bug/1243202)) to fix you'll need to chmod 644 that file.
+
+#### CentOS 6/7 with [isolated Python enviroments](http://docs.python-guide.org/en/latest/dev/virtualenvs/)
+
+Install
+```bash
+yum install gcc git python-setuptools python-devel
+git clone --depth 1 https://github.com/dinhoabreu/yowsup.git
+cd yowsup
+easy_install virtualenv
+virtualenv --no-pip yowsup-env
+source yowsup-env/bin/activate # Activate enviroment
+python setup.py install
+deactivate
+```
+
+Run yowsup-cli
+```bash
+source yowsup-env/bin/activate
+yowsup-cli ...
+deactivate
+```
 
 ### Mac
 ```

--- a/yowsup/layers/network/layer.py
+++ b/yowsup/layers/network/layer.py
@@ -1,4 +1,5 @@
 from yowsup.layers import YowLayer, YowLayerEvent
+from yowsup.proxy import HttpProxy
 import asyncore, socket, logging
 logger = logging.getLogger(__name__)
 
@@ -19,19 +20,39 @@ class YowNetworkLayer(YowLayer, asyncore.dispatcher_with_send):
     def __init__(self):
         YowLayer.__init__(self)
         asyncore.dispatcher.__init__(self)
+        httpProxy = HttpProxy.getFromEnviron()
+        proxyHandler = None
+        if httpProxy != None:
+            logger.debug("HttpProxy initialize: %s" % httpProxy)
+            def onConnect():
+                logger.debug("HttpProxy connected")
+                self.proxyHandler = None
+                self.handle_connect()
+            proxyHandler = httpProxy.handler()
+            proxyHandler.onConnect = onConnect
+        self.proxyHandler = proxyHandler
         
     def onEvent(self, ev):
         if ev.getName() == YowNetworkLayer.EVENT_STATE_CONNECT:
             self.create_socket(socket.AF_INET, socket.SOCK_STREAM)
             self.out_buffer = bytearray()
-            self.connect(self.getProp(self.__class__.PROP_ENDPOINT))
+            endpoint = self.getProp(self.__class__.PROP_ENDPOINT)
+            if self.proxyHandler != None:
+                logger.debug("HttpProxy connect: %s:%d" % endpoint)
+                self.proxyHandler.connect(self, endpoint)
+            else:
+                self.connect(endpoint)
             return True
         elif ev.getName() == YowNetworkLayer.EVENT_STATE_DISCONNECT:
             self.handle_close(ev.getArg("reason") or "Requested")
             return True
 
     def handle_connect(self):
-        self.emitEvent(YowLayerEvent(YowNetworkLayer.EVENT_STATE_CONNECTED))
+        if self.proxyHandler != None:
+            logger.debug("HttpProxy handle connect")
+            self.proxyHandler.send(self)
+        else:
+            self.emitEvent(YowLayerEvent(YowNetworkLayer.EVENT_STATE_CONNECTED))
 
     def handle_close(self, reason = "Connection Closed"):
         logger.debug("Disconnected, reason: %s" % reason)
@@ -44,8 +65,12 @@ class YowNetworkLayer(YowLayer, asyncore.dispatcher_with_send):
 
     def handle_read(self):
         readSize = self.getProp(self.__class__.PROP_NET_READSIZE, 1024)
-        data = self.recv(readSize)
-        self.receive(data)
+        if self.proxyHandler != None:
+            data = self.proxyHandler.recv(self, readSize)
+            logger.debug("HttpProxy handle read: %s" % data)
+        else:
+            data = self.recv(readSize)
+            self.receive(data)
 
     def send(self, data):
         self.out_buffer = self.out_buffer + data

--- a/yowsup/proxy/__init__.py
+++ b/yowsup/proxy/__init__.py
@@ -1,0 +1,1 @@
+from .http import HttpProxy

--- a/yowsup/proxy/http.py
+++ b/yowsup/proxy/http.py
@@ -1,0 +1,88 @@
+'''
+Copyright (c) <2012> Tarek Galal <tare2.galal@gmail.com>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this
+software and associated documentation files (the "Software"), to deal in the Software
+without restriction, including without limitation the rights to use, copy, modify,
+merge, publish, distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED,
+INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR
+A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF
+CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+'''
+
+import os, base64
+from urlparse import urlparse
+
+class HttpProxy:
+
+    def __init__(self, address, username = None, password = None):
+        self.address = address
+        self.username = username
+        self.password = password
+
+    def __repr__(self):
+        return repr(self.address)
+
+    def handler(self):
+        return HttpProxyHandler(self)
+
+    @staticmethod
+    def getFromEnviron():
+        url = None
+        for key in ('http_proxy', 'https_proxy'):
+            url = os.environ.get(key)
+            if url: break
+        if not url:
+            return None
+        dat = urlparse(url)
+        port = 80 if dat.scheme == 'http' else 443
+        if dat.port != None: port = int(dat.port)
+        host = dat.hostname
+        return HttpProxy((host, port), dat.username, dat.password)
+
+class HttpProxyHandler:
+
+    def __init__(self, proxy):
+        self.state = 'init'
+        self.proxy = proxy
+
+    def onConnect(self):
+        pass
+
+    def connect(self, socket, pair):
+        proxy = self.proxy
+        authHeader = None
+        if proxy.username and proxy.password:
+            auth = base64.b64encode(proxy.username + ':' + proxy.password)
+            authHeader = 'Proxy-Authorization: Basic ' + auth + '\r\n'
+        data = 'CONNECT %s:%d HTTP/1.1\r\nHost: %s:%d\r\n' % (2 * pair)
+        if authHeader:
+            data += authHeader
+        data += '\r\n'
+        self.state = 'connect'
+        self.data = data
+        socket.connect(proxy.address)
+
+    def send(self, socket):
+        if self.state == 'connect':
+            socket.send(self.data)
+            self.state = 'sent'
+
+    def recv(self, socket, size):
+        if self.state == 'sent':
+            data = socket.recv(size)
+            status = data.split(' ', 2)
+            if status[1] != '200':
+                raise Exception('%s' % (data[:data.index('\r\n')]))
+            self.state = 'end'
+            self.onConnect()
+            return data


### PR DESCRIPTION
I added a simple way to support proxy over all connections using environment variable http_proxy.
Examples:
```bash
export http_proxy="http://yourproxy:8080/" # or
export http_proxy="http://username:password@yourproxy:8080/" # for authenticated proxies
./yowsup-cli
```