### PR TITLE
Malformed dictionary was causing SyntaxError in Python 2.6

### DIFF
--- a/src/Yowsup/connectionmanager.py
+++ b/src/Yowsup/connectionmanager.py
@@ -805,7 +805,7 @@ class YowsupConnectionManager:
 			order += 1
 		if len(privacyNodes) > 0:
 			idx = self.makeId("privacy_setlist_")
-			listNode = ProtocolTreeNode("list", {"name", "default"}, privacyNodes)
+			listNode = ProtocolTreeNode("list", {"name": "default"}, privacyNodes)
 			queryNode = ProtocolTreeNode("query", None, [listNode])
 			iqNode = ProtocolTreeNode("iq", {"id": idx, "type": "set", "xmlns": "jabber:iq:privacy"}, [queryNode])
 			self._writeNode(iqNode)


### PR DESCRIPTION
A malformed dictionary was causing _SyntaxError_ in Python 2.6 and older.

```
File "connectionmanager.py", line 8
  listNode = ProtocolTreeNode("list", {"name", "default"}, privacyNodes)
                                             ^
SyntaxError: invalid syntax
```

**FIX**: Replaced `,` for `:`.
