### PR TITLE
Fix typing / composing call

### DIFF
--- a/src/Yowsup/connectionmanager.py
+++ b/src/Yowsup/connectionmanager.py
@@ -306,17 +306,19 @@ class YowsupConnectionManager:
 		
 		
 	def sendTyping(self,jid):
+		# Example: self.methodsInterface.call("typing_send", ([jid]))
 		self._d("SEND TYPING TO JID")
-		composing = ProtocolTreeNode("composing")
-		message = ProtocolTreeNode("chatstate",{"to":jid},[composing]);
+		composing = ProtocolTreeNode("composing", {"xmlns": "http://jabber.org/protocol/chatstates"})
+		message = ProtocolTreeNode("chatstate",{"to":jid,  "type": "chat"},[composing]);
 		self._writeNode(message);
 
 
 
 	def sendPaused(self,jid):
+		# Example: self.methodsInterface.call("typing_paused", ([jid]))
 		self._d("SEND PAUSED TO JID")
-		composing = ProtocolTreeNode("paused")
-		message = ProtocolTreeNode("chatstate",{"to":jid},[composing]);
+		composing = ProtocolTreeNode("paused", {"xmlns": "http://jabber.org/protocol/chatstates"})
+		message = ProtocolTreeNode("chatstate",{"to":jid,  "type": "chat"},[composing]);
 		self._writeNode(message);
 
 


### PR DESCRIPTION
I was getting when using sendTyping and sendPaused:

    composing = ProtocolTreeNode("composing")
    TypeError: __init__() takes at least 3 arguments (2 given)


This fixes it.