### PR TITLE
immediately write output data to socket

### DIFF
--- a/yowsup/layers/network/layer.py
+++ b/yowsup/layers/network/layer.py
@@ -47,6 +47,7 @@ class YowNetworkLayer(YowLayer, asyncore.dispatcher_with_send):
 
     def send(self, data):
         self.out_buffer = self.out_buffer + data
+        self.initiate_send()
 
     def receive(self, data):
         self.toUpper(data)


### PR DESCRIPTION
is there a reason to not call self.initiate_send() on network layer send()?

Not calling initiate_send() cases network tx delays, grouping some stanzas in same "batch".

Side effect: chatstate composing/paused and message is often sent on same "batch", making chatstate useless
