### PR TITLE
Ensure file handles are always closed

### DIFF
--- a/yowsup/layers/axolotl/protocolentities/iq_keys_set.py
+++ b/yowsup/layers/axolotl/protocolentities/iq_keys_set.py
@@ -35,9 +35,8 @@ class SetKeysIqProtocolEntity(IqProtocolEntity):
         return entity
 
     def log(self):
-        f = open("/home/tarek/yowdebug/keys_%s" % int(time.time()), "wb")
-        f.write(self.toProtocolTreeNode().__str__())
-        f.close()
+        with open("/home/tarek/yowdebug/keys_%s" % int(time.time()), "wb") as f:
+            f.write(self.toProtocolTreeNode().__str__())
 
     def toProtocolTreeNode(self):
         node = super(SetKeysIqProtocolEntity, self).toProtocolTreeNode()

--- a/yowsup/layers/protocol_media/mediadownloader.py
+++ b/yowsup/layers/protocol_media/mediadownloader.py
@@ -30,32 +30,31 @@ class MediaDownloader:
             u = urlopen(url)
             
             path = tempfile.mkstemp()[1]
-            f = open(path, "wb")
-            meta = u.info()
+            with open(path, "wb") as f:
+                meta = u.info()
 
-            if sys.version_info >= (3, 0):
-                fileSize = int(u.getheader("Content-Length"))
-            else:
-                fileSize = int(meta.getheaders("Content-Length")[0])
+                if sys.version_info >= (3, 0):
+                    fileSize = int(u.getheader("Content-Length"))
+                else:
+                    fileSize = int(meta.getheaders("Content-Length")[0])
 
-            fileSizeDl = 0
-            blockSz = 8192
-            lastEmit = 0
-            while True:
-                buf = u.read(blockSz)
-                
-                if not buf:
-                    break
+                fileSizeDl = 0
+                blockSz = 8192
+                lastEmit = 0
+                while True:
+                    buf = u.read(blockSz)
 
-                fileSizeDl += len(buf)
-                f.write(buf)
-                status = (fileSizeDl * 100 / fileSize)
-            
-                if self.progressCallback and lastEmit != status:
-                    self.progressCallback(int(status))
-                    lastEmit = status;
-            
-            f.close()
+                    if not buf:
+                        break
+
+                    fileSizeDl += len(buf)
+                    f.write(buf)
+                    status = (fileSizeDl * 100 / fileSize)
+
+                    if self.progressCallback and lastEmit != status:
+                        self.progressCallback(int(status))
+                        lastEmit = status;
+
             if self.successCallback:
                 self.successCallback(path)
         except:


### PR DESCRIPTION
This change ensures file handles are always closed by using the with statement. This means the file handles will be closed even when an exception occurs.