### PR TITLE
Fix quick login

### DIFF
--- a/yowsup/demos/cli/layer.py
+++ b/yowsup/demos/cli/layer.py
@@ -283,7 +283,7 @@ class YowsupCliLayer(Cli, YowInterfaceLayer):
 
     @clicmd("Quick login")
     def L(self):
-        return self.login(*self.getProp(YowAuthenticationProtocolLayer.PROP_CREDENTIALS))
+        return self.login(*self.getStack().getProp(YowAuthenticationProtocolLayer.PROP_CREDENTIALS))
 
     @clicmd("Login to WhatsApp", 0)
     def login(self, username, b64password):


### PR DESCRIPTION
Credentials are stored in the stack, as show in line 35 in stack.py, getStack() to fetch the credentials from the stack, as opposed from the layer (self)

Line 294 further shows how the credentials are stored in the stack self.getStack().setProp...

Without the fix, doing yowsup-cli demos --moxie -y -l <phone>:<pass> and then /L causes an exception.