### PR TITLE
Remove YowLoggerLayer from the core layers

### DIFF
--- a/yowsup/stacks/__init__.py
+++ b/yowsup/stacks/__init__.py
@@ -20,7 +20,6 @@ from yowsup.layers.protocol_privacy            import YowPrivacyProtocolLayer
 
 
 YOWSUP_CORE_LAYERS = (
-    YowLoggerLayer,
     YowCoderLayer,
     YowCryptLayer,
     YowStanzaRegulator,


### PR DESCRIPTION
It should be up to the developer to decide whether he wants the extra logging, so we should leave it out from the core layers that will almost always be included.