### PR TITLE
IncomingReceiptProtocolEntity :: added store of 'type' property

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,10 @@ deps = ['python-dateutil', 'argparse', 'python-axolotl>=0.1.1', 'pillow']
 if platform.system().lower() == "windows":
     deps.append('pyreadline')
 else:
-    deps.append('readline')
+    try:
+        import readline
+    except ImportError:
+        deps.append('readline')
 
 setup(
     name='yowsup2',

--- a/yowsup/layers/protocol_receipts/protocolentities/receipt_incoming.py
+++ b/yowsup/layers/protocol_receipts/protocolentities/receipt_incoming.py
@@ -13,24 +13,27 @@ class IncomingReceiptProtocolEntity(ReceiptProtocolEntity):
     <receipt offline="0" from="xxxxxxxxxx@s.whatsapp.net" id="1415577964-1" t="1415578027"></receipt>
     '''
 
-    def __init__(self, _id, _from, timestamp, offline = None):
+    def __init__(self, _id, _from, timestamp, offline = None, type = None):
         super(IncomingReceiptProtocolEntity, self).__init__(_id)
-        self.setIncomingData(_from, timestamp, offline)
+        self.setIncomingData(_from, timestamp, offline, type)
 
-    def setIncomingData(self, _from, timestamp, offline):
+    def setIncomingData(self, _from, timestamp, offline, type = None):
         self._from = _from
         self.timestamp = timestamp
+        self.type = type
         if offline is not None:
             self.offline = True if offline == "1" else False
         else:
             self.offline = None
-    
+
     def toProtocolTreeNode(self):
         node = super(IncomingReceiptProtocolEntity, self).toProtocolTreeNode()
         node.setAttribute("from", self._from)
         node.setAttribute("timestamp", self.timestamp)
         if self.offline is not None:
             node.setAttribute("1" if self.offline else "0")
+        if self.type is not None:
+            node.setAttribute("type", self.type)
         return node
 
     def __str__(self):
@@ -39,6 +42,8 @@ class IncomingReceiptProtocolEntity(ReceiptProtocolEntity):
         out += "Timestamp: \n%s" % self.timestamp
         if self.offline is not None:
             out += "Offline: %s\n" % ("1" if self.offline else "0")
+        if self.type is not None:
+            out += "Type: %s\n" % (self.type)
         return out
 
     @staticmethod
@@ -47,5 +52,6 @@ class IncomingReceiptProtocolEntity(ReceiptProtocolEntity):
             node.getAttributeValue("id"),
             node.getAttributeValue("from"),
             node.getAttributeValue("timestamp"),
-            node.getAttributeValue("offline"    )
+            node.getAttributeValue("offline"    ),
+            node.getAttributeValue("type")
             )


### PR DESCRIPTION
Now IncomingReceiptProtocolEntity stores the type, under the property 'type'. This is done in order to recognise if the IncomingReceipt is 'read'.
If the node has the property 'type' it is store, otherwise, type is left as None.