### PR TITLE
Photo caption text enabled in demo client application

### DIFF
--- a/yowsup/demos/cli/layer.py
+++ b/yowsup/demos/cli/layer.py
@@ -390,10 +390,11 @@ class YowsupCliLayer(Cli, YowInterfaceLayer):
        
 
     def getDownloadableMediaMessageBody(self, message):
-         return "[Media Type:{media_type}, Size:{media_size}, URL:{media_url}]".format(
+         return "[Media Type:{media_type}, Size:{media_size}, URL:{media_url}, CAP:{media_caption}]".format(
             media_type = message.getMediaType(),
             media_size = message.getMediaSize(),
-            media_url = message.getMediaUrl()
+            media_url = message.getMediaUrl(),
+            media_caption = message.getCaption()
             )
 
 


### PR DESCRIPTION
Although library supports caption text was missing in client demo application. In this commit it is added.