### PR TITLE
Fix receiving image callback (legacy)

### DIFF
--- a/src/Yowsup/Interfaces/DBus/DBusInterface.py
+++ b/src/Yowsup/Interfaces/DBus/DBusInterface.py
@@ -232,7 +232,7 @@ class DBusSignalInterface(SignalInterfaceBase, dbus.service.Object):
 
 
 	@dbus.service.signal(DBUS_INTERFACE)
-	def image_received(self, messageId, jid, preview, url, size, wantsReceipt, isBroadcast):
+	def image_received(self, messageId, jid, preview, url, size, caption, timestamp, wantsReceipt, pushName, isBroadcast):
 		pass
 
 	@dbus.service.signal(DBUS_INTERFACE)


### PR DESCRIPTION
As can be seen in: https://github.com/tgalal/yowsup/blob/legacy/src/Yowsup/connectionmanager.py#L1548

Now there are more parameters (mainly the new caption of photos) that must be passed throught.