### PR TITLE
Fix #755

### DIFF
--- a/yowsup/layers/protocol_calls/__init__.py
+++ b/yowsup/layers/protocol_calls/__init__.py
@@ -1,0 +1,1 @@
+from .layer import YowCallsProtocolLayer

--- a/yowsup/layers/protocol_calls/layer.py
+++ b/yowsup/layers/protocol_calls/layer.py
@@ -1,0 +1,29 @@
+from yowsup.layers import YowLayer, YowLayerEvent, YowProtocolLayer
+from .protocolentities import *
+from yowsup.layers.protocol_acks.protocolentities import OutgoingAckProtocolEntity
+from yowsup.layers.protocol_receipts.protocolentities import OutgoingReceiptProtocolEntity
+class YowCallsProtocolLayer(YowProtocolLayer):
+
+    def __init__(self):
+        handleMap = {
+            "call": (self.recvCall, self.sendCall)
+        }
+        super(YowCallsProtocolLayer, self).__init__(handleMap)
+
+    def __str__(self):
+        return "call Layer"
+
+    def sendCall(self, entity):
+        if entity.getTag() == "call":
+            self.toLower(entity.toProtocolTreeNode())
+
+    def recvCall(self, node):
+        entity = CallProtocolEntity.fromProtocolTreeNode(node)
+        if entity.getType() == "offer":
+            receipt = OutgoingReceiptProtocolEntity(node["id"], node["from"], callId = entity.getCallId())
+            self.toLower(receipt.toProtocolTreeNode())
+        else:
+            ack = OutgoingAckProtocolEntity(node["id"], "call", None, node["from"])
+            self.toLower(ack.toProtocolTreeNode())
+        self.toUpper(entity)
+

--- a/yowsup/layers/protocol_calls/protocolentities/__init__.py
+++ b/yowsup/layers/protocol_calls/protocolentities/__init__.py
@@ -1,0 +1,1 @@
+from .call                  import CallProtocolEntity

--- a/yowsup/layers/protocol_calls/protocolentities/call.py
+++ b/yowsup/layers/protocol_calls/protocolentities/call.py
@@ -1,0 +1,107 @@
+from yowsup.structs import ProtocolEntity, ProtocolTreeNode
+class CallProtocolEntity(ProtocolEntity):
+    '''
+    <call offline="0" from="{{CALLER_JID}}" id="{{ID}}" t="{{TIMESTAMP}}" notify="{{CALLER_PUSHNAME}}" retry="{{RETRY}}" e="{{?}}">
+    </call>
+    
+    '''
+    def __init__(self, _id, _type, timestamp, notify = None, offline = None, retry = None, e = None, callId = None, _from = None, _to = None):
+        super(CallProtocolEntity, self).__init__("call")
+        self._id            = _id or self._generateId()
+        self._type       = _type
+        self._from      = _from
+        self._to           = _to
+        self.timestamp  = int(timestamp)
+        self.notify     = notify
+        self.offline    = offline == "1"
+        self.retry      = retry
+        self.e             = e
+        self.callId     = callId
+
+    def __str__(self):
+        out = "Call\n"
+        if self.getFrom() is not None:
+            out += "From: %s\n" % self.getFrom()
+        if self.getTo() is not None:
+            out += "To: %s\n" % self.getTo()
+        if self.getType() is not None:
+            out += "Type: %s\n" % self.getType()
+        if self.getCallId() is not None:
+            out += "Call ID: %s\n" % self.getCallId()
+        return out
+
+    def getFrom(self):
+        return self._from
+        
+    def getTo(self):
+        return self._to
+
+    def getId(self):
+        return self._id
+        
+    def getType(self):
+        return self._type
+        
+    def getCallId(self):
+        return self.callId
+
+    def getTimestamp(self):
+        return self.timestamp
+
+    def toProtocolTreeNode(self):
+        children = []
+        attribs = {
+            "t"         : str(self.timestamp),
+            "offline"   : "1" if self.offline else "0",
+            "id"        : self._id,
+        }
+        if self._from is not None:
+            attribs["from"] = self._from
+        if self._to is not None:
+            attribs["to"] = self._to
+        if self.retry is not None:
+            attribs["retry"] = self.retry
+        if self.e is not None:
+            attribs["e"] = self.e
+        if self.notify is not None:
+            attribs["notify"] = self.notify
+        if self._type in ["offer", "transport", "relaylatency", "reject", "terminate"]:
+            child = ProtocolTreeNode(self._type, {"call-id": self.callId})
+            children.append(child)
+        return self._createProtocolTreeNode(attribs, children = children, data = None)
+
+    @staticmethod
+    def fromProtocolTreeNode(node):
+        (_type, callId) = [None] * 2
+        offer = node.getChild("offer")
+        transport = node.getChild("transport")
+        relaylatency = node.getChild("relaylatency")
+        reject = node.getChild("reject")
+        terminate = node.getChild("terminate")
+        if offer:
+            _type = "offer"
+            callId = offer.getAttributeValue("call-id")
+        elif transport:
+            _type = "transport"
+            callId = transport.getAttributeValue("call-id")
+        elif relaylatency:
+            _type = "relaylatency"
+            callId = relaylatency.getAttributeValue("call-id")
+        elif reject:
+            _type = "reject"
+            callId = reject.getAttributeValue("call-id")
+        elif terminate:
+            _type = "terminate"
+            callId = terminate.getAttributeValue("call-id")
+        return CallProtocolEntity(
+            node.getAttributeValue("id"),
+            _type,
+            node.getAttributeValue("t"),
+            node.getAttributeValue("notify"),
+            node.getAttributeValue("offline"),
+            node.getAttributeValue("retry"),
+            node.getAttributeValue("e"),
+            callId,
+            node.getAttributeValue("from"),
+            node.getAttributeValue("to")
+            )

--- a/yowsup/layers/protocol_calls/protocolentities/test_call.py
+++ b/yowsup/layers/protocol_calls/protocolentities/test_call.py
@@ -1,0 +1,17 @@
+from yowsup.layers.protocol_calls.protocolentities.call import CallProtocolEntity
+from yowsup.structs import ProtocolTreeNode
+from yowsup.structs.protocolentity import ProtocolEntityTest
+import unittest
+
+class CallProtocolEntityTest(ProtocolEntityTest, unittest.TestCase):
+    def setUp(self):
+        self.ProtocolEntity = CallProtocolEntity
+        children = [ProtocolTreeNode("offer", {"call-id": "call_id"})]
+        attribs = {
+            "t": "12345",
+            "from": "from_jid",
+            "offline": "0",
+            "id": "message_id",
+            "notify": "notify_name"
+        }
+        self.node = ProtocolTreeNode("call", attribs, children)

--- a/yowsup/layers/protocol_receipts/protocolentities/receipt_outgoing.py
+++ b/yowsup/layers/protocol_receipts/protocolentities/receipt_outgoing.py
@@ -17,14 +17,15 @@ class OutgoingReceiptProtocolEntity(ReceiptProtocolEntity):
     <receipt offline="0" from="4915225256022@s.whatsapp.net" id="1415577964-1" t="1415578027"></receipt>
     '''
 
-    def __init__(self, _id, to, read = False, participant = None):
+    def __init__(self, _id, to, read = False, participant = None, callId = None):
         super(OutgoingReceiptProtocolEntity, self).__init__(_id)
-        self.setOutgoingData(to, read, participant)
+        self.setOutgoingData(to, read, participant, callId)
 
-    def setOutgoingData(self, to, read, participant):
+    def setOutgoingData(self, to, read, participant, callId):
         self.to = to
         self.read = read
         self.participant = participant
+        self.callId = callId
     
     def toProtocolTreeNode(self):
         node = super(OutgoingReceiptProtocolEntity, self).toProtocolTreeNode()
@@ -32,6 +33,9 @@ class OutgoingReceiptProtocolEntity(ReceiptProtocolEntity):
             node.setAttribute("type", "read")
         if self.participant:
             node.setAttribute("participant", self.participant)
+        if self.callId:
+            offer = ProtocolTreeNode("offer", {"call-id": self.callId})
+            node.addChild(offer)
 
         node.setAttribute("to", self.to)
         node.setAttribute("t", str(int(time.time())))

--- a/yowsup/stacks/__init__.py
+++ b/yowsup/stacks/__init__.py
@@ -18,6 +18,7 @@ from yowsup.layers.protocol_contacts           import YowContactsIqProtocolLayer
 from yowsup.layers.protocol_chatstate          import YowChatstateProtocolLayer
 from yowsup.layers.protocol_privacy            import YowPrivacyProtocolLayer
 from yowsup.layers.protocol_profiles           import YowProfilesProtocolLayer
+from yowsup.layers.protocol_calls           import YowCallsProtocolLayer
 
 
 
@@ -41,7 +42,8 @@ YOWSUP_PROTOCOL_LAYERS_BASIC = (
 YOWSUP_PROTOCOL_LAYERS_GROUPS = (YowGroupsProtocolLayer,) + YOWSUP_PROTOCOL_LAYERS_BASIC
 YOWSUP_PROTOCOL_LAYERS_MEDIA  = (YowMediaProtocolLayer,) + YOWSUP_PROTOCOL_LAYERS_BASIC
 YOWSUP_PROTOCOL_LAYERS_PROFILES  = (YowProfilesProtocolLayer,) + YOWSUP_PROTOCOL_LAYERS_BASIC
-YOWSUP_PROTOCOL_LAYERS_FULL = (YowGroupsProtocolLayer, YowMediaProtocolLayer, YowPrivacyProtocolLayer, YowProfilesProtocolLayer)\
+YOWSUP_PROTOCOL_LAYERS_CALLS  = (YowCallsProtocolLayer,) + YOWSUP_PROTOCOL_LAYERS_BASIC
+YOWSUP_PROTOCOL_LAYERS_FULL = (YowGroupsProtocolLayer, YowMediaProtocolLayer, YowPrivacyProtocolLayer, YowProfilesProtocolLayer, YowCallsProtocolLayer)\
                               + YOWSUP_PROTOCOL_LAYERS_BASIC
 
 


### PR DESCRIPTION
This implements __basic__ ```<call>``` stanza support and thus prevents the ```<stream:error>``` and connection drop.
* ```<call>``` stanzas with an ```<offer  call-id="">``` child node are answered with a ```<receipt>``` stanza with the same ```<offer call-id="">``` node inside them.
* Any other type of call stanzas (```transport```, ```relaylatency```, ```reject```, ```terminate```) are answered with an ```<ack class="call">``` stanza with matching id.

__Usage recommendation__:
* Make sure ```YowCallsProtocolLayer``` is in your stack. The ```YOWSUP_PROTOCOL_LAYERS_FULL``` stock stack already includes it.
* Listen to call offers from your layer and reject them like this:
```python
@ProtocolEntityCallback("call")
    def onCall(self, entity):
        if entity.getType() == "offer":
          call = CallProtocolEntity(None, "reject", int(time.time()), _to = entity.getFrom(), callId = entity.getCallId())
          self.toLower(call)
```

Special acknowledgements to @mgp25 as this fix has been ported from his __Chat API__ project.