### PR TITLE
Fix #620

### DIFF
--- a/yowsup/layers/protocol_profiles/protocolentities/iq_picture.py
+++ b/yowsup/layers/protocol_profiles/protocolentities/iq_picture.py
@@ -25,15 +25,18 @@ class PictureIqProtocolEntity(IqProtocolEntity):
     '''
     XMLNS = "w:profile:picture"
 
-    def __init__(self, jid):
-        super(PictureIqProtocolEntity, self).__init__(self.__class__.XMLNS, _type="get", to = jid)
-        self.pictureId = None
+    def __init__(self, jid, _id = None, type = "get"):
+        super(PictureIqProtocolEntity, self).__init__(self.__class__.XMLNS, _id = _id, _type=type, to = jid)
         self.pictureData = None
+        self.previewData = None
+        self.pictureId = None
 
     def __str__(self):
         out  = super(PictureIqProtocolEntity, self).__str__()
         if self.pictureData is not None:
             out += "pictureData: Binary data\n"
+        if self.previewData is not None:
+            out += "previewData: Binary data\n"
         if self.pictureId is not None:
             out += "pictureId: %s\n" % self.pictureId
         return out
@@ -42,6 +45,12 @@ class PictureIqProtocolEntity(IqProtocolEntity):
         self.pictureData = pictureData
 
     def getPictureData(self):
+        return self.pictureData
+
+    def setPreviewData(self, previewData):
+        self.previewData = previewData
+        
+    def getPreviewData(self):
         return self.pictureData
 
     def setPictureId(self, pictureId):
@@ -54,22 +63,31 @@ class PictureIqProtocolEntity(IqProtocolEntity):
         node = super(PictureIqProtocolEntity, self).toProtocolTreeNode()
         if self._type == "set" and self.pictureId is None:
             self.pictureId = self._generateId(True)
-        if self.pictureId is None:
-            attribs = {"type": "image"}
-        else:
+        if self.pictureId is not None:
             attribs = {"type": "image", "id": self.pictureId}
-        pictureNode = ProtocolTreeNode("picture", attribs, None, self.pictureData)
-        node.addChild(pictureNode)
+        else:
+            attribs = {"type": "image"}
+        if self.pictureData is not None:
+          pictureNode = ProtocolTreeNode("picture", attribs, None, self.pictureData)
+          node.addChild(pictureNode)
+        if self.previewData is not None:
+          previewNode = ProtocolTreeNode("picture", {"type": "preview"}, None, self.previewData)
+          node.addChild(previewNode)
         return node
 
     @staticmethod
     def fromProtocolTreeNode(node):
         entity = IqProtocolEntity.fromProtocolTreeNode(node)
         entity.__class__ = PictureIqProtocolEntity
-        pictureNode = node.getChild("picture")
-        assert pictureNode["type"] == "image", "Not a profile picture with type image, got %s" \
-            % pictureNode["type"]
-        entity.setPictureData(pictureNode.getData())
-        entity.setPictureId(pictureNode["id"])
+        entity.__init__(entity.to, entity._id, entity._type)
+        children = node.getAllChildren("picture")
+        for child in children:
+          nodeType = child.getAttributeValue("type")
+          if nodeType == "image":
+            entity.setPictureData(child.getData())
+            entity.setPictureId(child["id"])
+          elif nodeType == "preview":
+            entity.setPreviewData(child.getData())
+          else:
+            entity.setPictureId(child["id"])
         return entity
-


### PR DESCRIPTION
Picture setting ```iq``` were being rejected because they lacked the ```preview``` child.

__Usage recommendation:__
The picture itself MAY have an ideal size of 640x640 pixels and previews SHOULD be 96x96px.

Example for your layer:
```python
from PIL import Image

src = Image.open(path) 
iq = PictureIqProtocolEntity(self.normalizeJid(mynumber), type="set")
iq.setPictureData(bytearray(src.resize((640, 640)).tostring("jpeg", "RGB")))
iq.setPreviewData(bytearray(src.resize((96, 96)).tostring("jpeg", "RGB")))
self.toLower(iq)
```