### PR TITLE
Fix #561 and #592

### DIFF
--- a/yowsup/layers/protocol_notifications/layer.py
+++ b/yowsup/layers/protocol_notifications/layer.py
@@ -19,7 +19,9 @@ class YowNotificationsProtocolLayer(YowProtocolLayer):
     def recvNotification(self, node):
         if node["type"] == "picture":
             if node.getChild("set"):
-                self.toUpper(PictureNotificationProtocolEntity.fromProtocolTreeNode(node))
+                self.toUpper(SetPictureNotificationProtocolEntity.fromProtocolTreeNode(node))
+            elif node.getChild("delete"):
+                self.toUpper(DeletePictureNotificationProtocolEntity.fromProtocolTreeNode(node))
             else:
                 self.raiseErrorForNode(node)
         elif node["type"] == "status":

--- a/yowsup/layers/protocol_notifications/protocolentities/__init__.py
+++ b/yowsup/layers/protocol_notifications/protocolentities/__init__.py
@@ -1,4 +1,5 @@
 from .notification                  import NotificationProtocolEntity
 from .notification_picture          import PictureNotificationProtocolEntity
 from .notification_picture_set      import SetPictureNotificationProtocolEntity
+from .notification_picture_delete      import DeletePictureNotificationProtocolEntity
 from .notification_status           import StatusNotificationProtocolEntity

--- a/yowsup/layers/protocol_notifications/protocolentities/notification_picture_delete.py
+++ b/yowsup/layers/protocol_notifications/protocolentities/notification_picture_delete.py
@@ -1,0 +1,31 @@
+from yowsup.structs import ProtocolEntity, ProtocolTreeNode
+from .notification_picture import PictureNotificationProtocolEntity
+class DeletePictureNotificationProtocolEntity(PictureNotificationProtocolEntity):
+    '''
+    <notification offline="0" id="{{NOTIFICATION_ID}}" notify="{{NOTIFY_NAME}}" type="picture" 
+            t="{{TIMESTAMP}}" from="{{SENDER_JID}}">
+        <delete jid="{{DELETE_JID}}">
+        </delete>
+    </notification>
+    '''
+
+    def __init__(self, _id,  _from, status, timestamp, notify, offline, deleteJid):
+        super(DeletePictureNotificationProtocolEntity, self).__init__(_id, _from, timestamp, notify, offline)
+        self.setData(deleteJid)
+
+    def setData(self, deleteJid):
+        self.deleteJid =   deleteJid
+    
+    def toProtocolTreeNode(self):
+        node = super(DeletePictureNotificationProtocolEntity, self).toProtocolTreeNode()
+        deleteNode = ProtocolTreeNode("delete", {"jid": self.deleteJid}, None, None)
+        node.addChild(deleteNode)
+        return node
+
+    @staticmethod
+    def fromProtocolTreeNode(node):
+        entity = PictureNotificationProtocolEntity.fromProtocolTreeNode(node)
+        entity.__class__ = DeletePictureNotificationProtocolEntity
+        deleteNode = node.getChild("delete")
+        entity.setData(deleteNode.getAttributeValue("jid"))
+        return entity

--- a/yowsup/layers/protocol_notifications/protocolentities/test_notification_picture_delete.py
+++ b/yowsup/layers/protocol_notifications/protocolentities/test_notification_picture_delete.py
@@ -1,0 +1,10 @@
+from yowsup.layers.protocol_notifications.protocolentities.notification_picture_delete import DeletePictureNotificationProtocolEntity
+from yowsup.structs import ProtocolTreeNode
+from yowsup.layers.protocol_notifications.protocolentities.test_notification_picture import PictureNotificationProtocolEntityTest
+
+class DeletePictureNotificationProtocolEntityTest(PictureNotificationProtocolEntityTest):
+    def setUp(self):
+        super(DeletePictureNotificationProtocolEntityTest, self).setUp()
+        self.ProtocolEntity = DeletePictureNotificationProtocolEntity
+        deleteNode = ProtocolTreeNode("delete", {"jid": "DELETE_JID"}, None, None)
+        self.node.addChild(deleteNode)

--- a/yowsup/layers/protocol_notifications/protocolentities/test_notification_picture_set.py
+++ b/yowsup/layers/protocol_notifications/protocolentities/test_notification_picture_set.py
@@ -6,5 +6,5 @@ class SetPictureNotificationProtocolEntityTest(PictureNotificationProtocolEntity
     def setUp(self):
         super(SetPictureNotificationProtocolEntityTest, self).setUp()
         self.ProtocolEntity = SetPictureNotificationProtocolEntity
-        setNode = ProtocolTreeNode("set", {"id": "SET_JID", "jid": "123"}, None, None)
+        setNode = ProtocolTreeNode("set", {"jid": "SET_JID", "id": "123"}, None, None)
         self.node.addChild(setNode)


### PR DESCRIPTION
This implements support for notifications with ```delete``` children:
```xml
<notification offline="0" id="{{NOTIFICATION_ID}}" notify="{{NOTIFY_NAME}}" type="picture" t="{{TIMESTAMP}}" from="{{SENDER_JID}}">
  <delete jid="{{DELETE_JID}}">
  </delete>
</notification>
```