### PR TITLE
Fix #834

### DIFF
--- a/yowsup/layers/protocol_profiles/layer.py
+++ b/yowsup/layers/protocol_profiles/layer.py
@@ -1,4 +1,5 @@
 from yowsup.layers import  YowProtocolLayer
+from yowsup.layers.protocol_iq.protocolentities import ErrorIqProtocolEntity
 from .protocolentities import *
 class YowProfilesProtocolLayer(YowProtocolLayer):
     def __init__(self):
@@ -22,4 +23,8 @@ class YowProfilesProtocolLayer(YowProtocolLayer):
             if pictureNode is not None:
                 entity = ResultGetPictureIqProtocolEntity.fromProtocolTreeNode(node)
                 self.toUpper(entity)
+        elif node["type"] == "error":
+            entity = ErrorIqProtocolEntity.fromProtocolTreeNode(node)
+            self.toUpper(entity)
+
 


### PR DESCRIPTION
With this fix, now you can do this:
```python
def success(resultIq, requestIq):
  print "Success!"

def error(errorIq, requestIq):
  print "Fail! Reason: %s" % errorIq.text

iq = GetPictureIqProtocolEntity(jid)
self._sendIq(iq, success, error)
```
Before the fix, the `error` callback was never being called.