### PR TITLE
Ack and forward convenience functions

### DIFF
--- a/yowsup/demos/echoclient/layer.py
+++ b/yowsup/demos/echoclient/layer.py
@@ -12,65 +12,31 @@ class EchoLayer(YowInterfaceLayer):
     @ProtocolEntityCallback("message")
     def onMessage(self, messageProtocolEntity):
 
-        if not messageProtocolEntity.isGroupMessage():
-            if messageProtocolEntity.getType() == 'text':
-                self.onTextMessage(messageProtocolEntity)
-            elif messageProtocolEntity.getType() == 'media':
-                self.onMediaMessage(messageProtocolEntity)
+        if messageProtocolEntity.getType() == 'text':
+            self.onTextMessage(messageProtocolEntity)
+        elif messageProtocolEntity.getType() == 'media':
+            self.onMediaMessage(messageProtocolEntity)
+
+        self.toLower(messageProtocolEntity.forward(messageProtocolEntity.getFrom()))
+        self.toLower(messageProtocolEntity.ack())
+        self.toLower(messageProtocolEntity.ack(True))
+	
     
     @ProtocolEntityCallback("receipt")
     def onReceipt(self, entity):
-        ack = OutgoingAckProtocolEntity(entity.getId(), "receipt", "delivery")
-        self.toLower(ack)
+        self.toLower(entity.ack())
 
     def onTextMessage(self,messageProtocolEntity):
-        receipt = OutgoingReceiptProtocolEntity(messageProtocolEntity.getId(), messageProtocolEntity.getFrom())
-            
-        outgoingMessageProtocolEntity = TextMessageProtocolEntity(
-            messageProtocolEntity.getBody(),
-            to = messageProtocolEntity.getFrom())
-
+	# just print info
         print("Echoing %s to %s" % (messageProtocolEntity.getBody(), messageProtocolEntity.getFrom(False)))
 
-        #send receipt otherwise we keep receiving the same message over and over
-        self.toLower(receipt)
-        self.toLower(outgoingMessageProtocolEntity)
-
     def onMediaMessage(self, messageProtocolEntity):
+	# just print info
         if messageProtocolEntity.getMediaType() == "image":
-            
-            receipt = OutgoingReceiptProtocolEntity(messageProtocolEntity.getId(), messageProtocolEntity.getFrom())
-
-            outImage = ImageDownloadableMediaMessageProtocolEntity(
-                messageProtocolEntity.getMimeType(), messageProtocolEntity.fileHash, messageProtocolEntity.url, messageProtocolEntity.ip,
-                messageProtocolEntity.size, messageProtocolEntity.fileName, messageProtocolEntity.encoding, messageProtocolEntity.width, messageProtocolEntity.height,
-                messageProtocolEntity.getCaption(),
-                to = messageProtocolEntity.getFrom(), preview = messageProtocolEntity.getPreview())
-
             print("Echoing image %s to %s" % (messageProtocolEntity.url, messageProtocolEntity.getFrom(False)))
 
-            #send receipt otherwise we keep receiving the same message over and over
-            self.toLower(receipt)
-            self.toLower(outImage)
-
         elif messageProtocolEntity.getMediaType() == "location":
-
-            receipt = OutgoingReceiptProtocolEntity(messageProtocolEntity.getId(), messageProtocolEntity.getFrom())
-
-            outLocation = LocationMediaMessageProtocolEntity(messageProtocolEntity.getLatitude(),
-                messageProtocolEntity.getLongitude(), messageProtocolEntity.getLocationName(),
-                messageProtocolEntity.getLocationURL(), messageProtocolEntity.encoding,
-                to = messageProtocolEntity.getFrom(), preview=messageProtocolEntity.getPreview())
-
             print("Echoing location (%s, %s) to %s" % (messageProtocolEntity.getLatitude(), messageProtocolEntity.getLongitude(), messageProtocolEntity.getFrom(False)))
 
-            #send receipt otherwise we keep receiving the same message over and over
-            self.toLower(outLocation)
-            self.toLower(receipt)
         elif messageProtocolEntity.getMediaType() == "vcard":
-            receipt = OutgoingReceiptProtocolEntity(messageProtocolEntity.getId(), messageProtocolEntity.getFrom())
-            outVcard = VCardMediaMessageProtocolEntity(messageProtocolEntity.getName(),messageProtocolEntity.getCardData(),to = messageProtocolEntity.getFrom())
             print("Echoing vcard (%s, %s) to %s" % (messageProtocolEntity.getName(), messageProtocolEntity.getCardData(), messageProtocolEntity.getFrom(False)))
-            #send receipt otherwise we keep receiving the same message over and over
-            self.toLower(outVcard)
-            self.toLower(receipt)

--- a/yowsup/layers/protocol_messages/protocolentities/message.py
+++ b/yowsup/layers/protocol_messages/protocolentities/message.py
@@ -1,4 +1,7 @@
 from yowsup.structs import ProtocolEntity, ProtocolTreeNode
+from yowsup.layers.protocol_receipts.protocolentities  import OutgoingReceiptProtocolEntity
+from copy import deepcopy
+
 class MessageProtocolEntity(ProtocolEntity):
 
     MESSAGE_TYPE_TEXT = "text"
@@ -93,9 +96,20 @@ class MessageProtocolEntity(ProtocolEntity):
         out += "ID: %s\n" % self._id
         out += "To: %s\n" % self.to  if self.isOutgoing() else "From: %s\n" % self._from 
         out += "Type:  %s\n" % self._type
+        out += "Timestamp: %s\n" % self.timestamp
         if self.participant:
             out += "Participant: %s\n" % self.participant
         return out
+
+    def ack(self, read=False):
+        return OutgoingReceiptProtocolEntity(self.getId(), self.getFrom(), read, participant=self.getParticipant())
+
+    def forward(self, to, _id = None):
+        OutgoingMessage = deepcopy(self)
+        OutgoingMessage.to = to
+        OutgoingMessage._from = None
+        OutgoingMessage._id = self._generateId() if _id is None else _id
+        return OutgoingMessage
 
     @staticmethod
     def fromProtocolTreeNode(node):

--- a/yowsup/layers/protocol_notifications/protocolentities/notification.py
+++ b/yowsup/layers/protocol_notifications/protocolentities/notification.py
@@ -1,4 +1,6 @@
 from yowsup.structs import ProtocolEntity, ProtocolTreeNode
+from yowsup.layers.protocol_receipts.protocolentities  import OutgoingReceiptProtocolEntity
+
 class NotificationProtocolEntity(ProtocolEntity):
     '''
     <notification offline="0" id="{{NOTIFICATION_ID}}" notify="{{NOTIFY_NAME}}" type="{{NOTIFICATION_TYPE}}" 
@@ -23,8 +25,8 @@ class NotificationProtocolEntity(ProtocolEntity):
         out += "Type: %s\n" % self.getType()
         return out
 
-    def getFrom(self):
-        return self._from
+    def getFrom(self, full = True):
+        return self._from if full else self._from.split('@')[0]
 
     def getType(self):
         return self._type
@@ -46,6 +48,9 @@ class NotificationProtocolEntity(ProtocolEntity):
         }
        
         return self._createProtocolTreeNode(attribs, children = None, data = None)
+
+    def ack(self):
+        return OutgoingReceiptProtocolEntity(self.getId(), self.getFrom())
 
     @staticmethod
     def fromProtocolTreeNode(node):

--- a/yowsup/layers/protocol_receipts/protocolentities/receipt_incoming.py
+++ b/yowsup/layers/protocol_receipts/protocolentities/receipt_incoming.py
@@ -1,5 +1,7 @@
 from yowsup.structs import ProtocolEntity, ProtocolTreeNode
 from .receipt import ReceiptProtocolEntity
+from yowsup.layers.protocol_acks.protocolentities  import OutgoingAckProtocolEntity
+
 class IncomingReceiptProtocolEntity(ReceiptProtocolEntity):
 
     '''
@@ -17,6 +19,12 @@ class IncomingReceiptProtocolEntity(ReceiptProtocolEntity):
         super(IncomingReceiptProtocolEntity, self).__init__(_id)
         self.setIncomingData(_from, timestamp, offline, type)
 
+    def getType(self):
+        return self.type
+
+    def getFrom(self, full = True):
+        return self._from if full else self._from.split('@')[0]
+
     def setIncomingData(self, _from, timestamp, offline, type = None):
         self._from = _from
         self.timestamp = timestamp
@@ -29,29 +37,32 @@ class IncomingReceiptProtocolEntity(ReceiptProtocolEntity):
     def toProtocolTreeNode(self):
         node = super(IncomingReceiptProtocolEntity, self).toProtocolTreeNode()
         node.setAttribute("from", self._from)
-        node.setAttribute("timestamp", str(self.timestamp))
+        node.setAttribute("t", str(self.timestamp))
         if self.offline is not None:
-            node.setAttribute("1" if self.offline else "0")
+            node.setAttribute("offline", "1" if self.offline else "0")
         if self.type is not None:
             node.setAttribute("type", self.type)
         return node
 
     def __str__(self):
         out = super(IncomingReceiptProtocolEntity, self).__str__()
-        out += "From: \n%s" % self._from
-        out += "Timestamp: \n%s" % self.timestamp
+        out += "From: %s\n" % self._from
+        out += "Timestamp: %s\n" % self.timestamp
         if self.offline is not None:
             out += "Offline: %s\n" % ("1" if self.offline else "0")
         if self.type is not None:
             out += "Type: %s\n" % (self.type)
         return out
 
+    def ack(self):
+        return OutgoingAckProtocolEntity(self.getId(), "receipt", self.getType(), self.getFrom())
+
     @staticmethod
     def fromProtocolTreeNode(node):
         return IncomingReceiptProtocolEntity(
             node.getAttributeValue("id"),
             node.getAttributeValue("from"),
-            node.getAttributeValue("timestamp"),
-            node.getAttributeValue("offline"    ),
+            node.getAttributeValue("t"),
+            node.getAttributeValue("offline"),
             node.getAttributeValue("type")
             )


### PR DESCRIPTION
simpler functions for forwarding in message protocol:
       - messageProtocolEntity.forward(to)

simpler functions for receipt and ack in notification, message and receipt layers. No necesary to check if group message or broadcast is required anymore:
       - message.ack(read)
       - notification.ack()
       - receipt.ack()


Demos are adapted too