### PR TITLE
fix TypeError with hashlib on python 2.6

### DIFF
--- a/yowsup/env/env_android.py
+++ b/yowsup/env/env_android.py
@@ -52,7 +52,11 @@ class AndroidYowsupEnv(YowsupEnv):
             ipad.append(0x36 ^ keyDecoded[i])
         hash = hashlib.sha1()
         subHash = hashlib.sha1()
-        subHash.update(ipad + data)
-        hash.update(opad + subHash.digest())
+        try:
+            subHash.update(ipad + data)
+            hash.update(opad + subHash.digest())
+        except TypeError:
+            subHash.update(bytes(ipad + data))
+            hash.update(bytes(opad + subHash.digest()))
         result = base64.b64encode(hash.digest())
         return result


### PR DESCRIPTION
fix for "TypeError: update() argument 1 must be string or read-only buffer, not bytearray" with python 2.6
