### PR TITLE
close socket before create

### DIFF
--- a/yowsup/layers/network/layer.py
+++ b/yowsup/layers/network/layer.py
@@ -36,6 +36,8 @@ class YowNetworkLayer(YowLayer, asyncore.dispatcher_with_send):
 
     def onEvent(self, ev):
         if ev.getName() == YowNetworkLayer.EVENT_STATE_CONNECT:
+
+
             self.createConnection()
             return True
         elif ev.getName() == YowNetworkLayer.EVENT_STATE_DISCONNECT:
@@ -43,6 +45,16 @@ class YowNetworkLayer(YowLayer, asyncore.dispatcher_with_send):
             return True
 
     def createConnection(self):
+		#in case the socket as already been opened but is an invalid state - reset it
+        self.connected = False
+        self.accepting = False
+        self.connecting = False
+        self.close()
+        try:
+            if self.socket is not None:
+                self.socket.close()
+        except Exception:
+            pass
         self.create_socket(socket.AF_INET, socket.SOCK_STREAM)
         self.out_buffer = bytearray()
         endpoint = self.getProp(self.__class__.PROP_ENDPOINT)


### PR DESCRIPTION
under windows broadcasting EVENT_STATE_CONNECT after socket stops working doesn't reconnect.
Added a close() before attemting to connect