### PR TITLE
Random endpoints selection

### DIFF
--- a/yowsup/common/constants.py
+++ b/yowsup/common/constants.py
@@ -1,6 +1,21 @@
 class YowConstants:
     DOMAIN       = "s.whatsapp.net"
     ENDPOINTS     = (
+        ("e1.whatsapp.net", 443),
+        ("e2.whatsapp.net", 443),
+        ("e3.whatsapp.net", 443),
+        ("e4.whatsapp.net", 443),
+        ("e5.whatsapp.net", 443),
+        ("e6.whatsapp.net", 443),
+        ("e7.whatsapp.net", 443),
+        ("e8.whatsapp.net", 443),
+        ("e9.whatsapp.net", 443),
+        ("e10.whatsapp.net", 443),
+        ("e11.whatsapp.net", 443),
+        ("e12.whatsapp.net", 443),
+        ("e13.whatsapp.net", 443),
+        ("e14.whatsapp.net", 443),
+        ("e15.whatsapp.net", 443),
         ("e16.whatsapp.net", 443),
         )
 

--- a/yowsup/demos/contacts/stack.py
+++ b/yowsup/demos/contacts/stack.py
@@ -46,10 +46,7 @@ class YowsupSyncStack(object):
         self.stack = YowStack(layers)
         self.stack.setProp(SyncLayer.PROP_CONTACTS, contacts)
         self.stack.setProp(YowAuthenticationProtocolLayer.PROP_PASSIVE, True)
-        self.stack.setProp(YowAuthenticationProtocolLayer.PROP_CREDENTIALS, credentials)
-        self.stack.setProp(YowNetworkLayer.PROP_ENDPOINT, YowConstants.ENDPOINTS[0])
-        self.stack.setProp(YowCoderLayer.PROP_DOMAIN, YowConstants.DOMAIN)
-        self.stack.setProp(YowCoderLayer.PROP_RESOURCE, env.CURRENT_ENV.getResource())
+        self.stack.setCredentials(credentials)
 
     def start(self):
         self.stack.broadcastEvent(YowLayerEvent(YowNetworkLayer.EVENT_STATE_CONNECT))

--- a/yowsup/demos/echoclient/stack.py
+++ b/yowsup/demos/echoclient/stack.py
@@ -41,10 +41,7 @@ class YowsupEchoStack(object):
             )
 
         self.stack = YowStack(layers)
-        self.stack.setProp(YowAuthenticationProtocolLayer.PROP_CREDENTIALS, credentials)
-        self.stack.setProp(YowNetworkLayer.PROP_ENDPOINT, YowConstants.ENDPOINTS[0])
-        self.stack.setProp(YowCoderLayer.PROP_DOMAIN, YowConstants.DOMAIN)
-        self.stack.setProp(YowCoderLayer.PROP_RESOURCE, env.CURRENT_ENV.getResource())
+        self.stack.setCredentials(credentials)
 
     def start(self):
         self.stack.broadcastEvent(YowLayerEvent(YowNetworkLayer.EVENT_STATE_CONNECT))

--- a/yowsup/demos/sendclient/stack.py
+++ b/yowsup/demos/sendclient/stack.py
@@ -46,10 +46,7 @@ class YowsupSendStack(object):
         self.stack = YowStack(layers)
         self.stack.setProp(SendLayer.PROP_MESSAGES, messages)
         self.stack.setProp(YowAuthenticationProtocolLayer.PROP_PASSIVE, True)
-        self.stack.setProp(YowAuthenticationProtocolLayer.PROP_CREDENTIALS, credentials)
-        self.stack.setProp(YowNetworkLayer.PROP_ENDPOINT, YowConstants.ENDPOINTS[0])
-        self.stack.setProp(YowCoderLayer.PROP_DOMAIN, YowConstants.DOMAIN)
-        self.stack.setProp(YowCoderLayer.PROP_RESOURCE, env.CURRENT_ENV.getResource())
+        self.stack.setCredentials(credentials)
 
     def start(self):
         self.stack.broadcastEvent(YowLayerEvent(YowNetworkLayer.EVENT_STATE_CONNECT))

--- a/yowsup/stacks/yowstack.py
+++ b/yowsup/stacks/yowstack.py
@@ -1,5 +1,5 @@
 from yowsup.layers import YowParallelLayer
-import asyncore, time, logging
+import asyncore, time, logging, random
 from yowsup.layers import YowLayer
 from yowsup.layers.auth                        import YowCryptLayer, YowAuthenticationProtocolLayer
 from yowsup.layers.coder                       import YowCoderLayer
@@ -126,7 +126,7 @@ class YowStack(object):
         self._construct()
         self._props = {}
 
-        self.setProp(YowNetworkLayer.PROP_ENDPOINT, YowConstants.ENDPOINTS[0])
+        self.setProp(YowNetworkLayer.PROP_ENDPOINT, YowConstants.ENDPOINTS[random.randint(0,len(YowConstants.ENDPOINTS)-1)])
         self.setProp(YowCoderLayer.PROP_DOMAIN, YowConstants.DOMAIN)
         self.setProp(YowCoderLayer.PROP_RESOURCE, env.CURRENT_ENV.getResource())
 


### PR DESCRIPTION
Endpoints are selected randomly, so detection of unofficial API 'harder'.

Perhaps timeout event should be managed in network layer and retried in other endpoints.

Some unnecesary properties removed from demos to make them sorter.