### PR TITLE
extracted main function in yowsup-cli to allow running it directly with specified args

### DIFF
--- a/yowsup-cli
+++ b/yowsup-cli
@@ -58,8 +58,8 @@ class YowArgParser(argparse.ArgumentParser):
             print("Invalid config path: %s" % config)
             sys.exit(1)
 
-    def process(self):
-        self.args = vars(self.parse_args())
+    def process(self, args):
+        self.args = vars(self.parse_args(args))
         if self.args["version"]:
             print("yowsup-cli v%s\nUsing yowsup v%s" % (__version__, yowsup.__version__))
             sys.exit(0)
@@ -119,8 +119,8 @@ class RegistrationArgParser(YowArgParser):
         regSteps.add_argument("-r", '--requestcode', help='Request the digit registration code from Whatsapp.', action="store", required=False, metavar="(sms|voice)")
         regSteps.add_argument("-R", '--register', help='Register account on Whatsapp using the code you previously received', action="store", required=False, metavar="code")
 
-    def process(self):
-        super(RegistrationArgParser, self).process()
+    def process(self, args):
+        super(RegistrationArgParser, self).process(args)
 
         config = self.getConfig(self.args["config"]) if self.args["config"] else {}
 
@@ -220,8 +220,8 @@ class DemosArgParser(YowArgParser):
         syncContacts = self.add_argument_group("Sync contacts")
         syncContacts.add_argument('-S','--sync', action = "store" , help = "Sync ( check valid ) whatsapp contacts",metavar =("contacts"))
 
-    def process(self):
-        super(DemosArgParser, self).process()
+    def process(self, args):
+        super(DemosArgParser, self).process(args)
 
         if self.args["yowsup"]:
             self.startCmdline()
@@ -315,7 +315,7 @@ def run_main(args):
         sys.exit(0)
     else:
         parser = mode_dict[mode]()
-        if not parser.process():
+        if not parser.process(args[1:]):
             parser.print_help()
 
 

--- a/yowsup-cli
+++ b/yowsup-cli
@@ -296,21 +296,16 @@ class DemosArgParser(YowArgParser):
             sys.exit(0)
 
 
-if __name__ == "__main__":
-    args = sys.argv
-    if(len(args) > 1):
-        del args[0]
-
-
-    modeDict = {
-        "demos":        DemosArgParser,
+def run_main(args):
+    mode_dict = {
+        "demos": DemosArgParser,
         "registration": RegistrationArgParser,
-        "version":      None
+        "version": None
     }
 
-    if(len(args) == 0 or args[0] not in modeDict):
+    if len(args) == 0 or args[0] not in mode_dict:
         print("Available commands:\n===================")
-        print(", ".join(modeDict.keys()))
+        print(", ".join(mode_dict.keys()))
 
         sys.exit(1)
 
@@ -319,6 +314,13 @@ if __name__ == "__main__":
         print("yowsup-cli v%s\nUsing yowsup v%s" % (__version__, yowsup.__version__))
         sys.exit(0)
     else:
-        parser = modeDict[mode]()
+        parser = mode_dict[mode]()
         if not parser.process():
             parser.print_help()
+
+
+if __name__ == "__main__":
+    args = sys.argv
+    if len(args) > 1:
+        del args[0]
+    run_main(args)


### PR DESCRIPTION
It makes possible to run yowsup-cli directly from other python code with some arguments, without having to use a new OS process for that. Like for example

    # import it somehow (non-standard name is another obstacle here, but it's possible even now)
    import imp
    yowsup_cli = imp.load_source('yowsup_cli', 'yowsup-cli')

    # and it cal be called just like a "real" "full" cli script
    yowsup_cli.run_main(['demos', '-d', '-l', '%s:%s' % (PHONE_NUMBER, PASSWORD), '-y'])

