### PR TITLE
fix erroneous method in LiteAxolotlStore

### DIFF
--- a/yowsup/layers/axolotl/store/sqlite/liteaxolotlstore.py
+++ b/yowsup/layers/axolotl/store/sqlite/liteaxolotlstore.py
@@ -74,4 +74,4 @@ class LiteAxolotlStore(AxolotlStore):
         return self.signedPreKeyStore.containsSignedPreKey(signedPreKeyId)
 
     def removeSignedPreKey(self, signedPreKeyId):
-        return self.signedPreKeyStore.containsSignedPreKey()
+        self.signedPreKeyStore.removeSignedPreKey(signedPreKeyId)


### PR DESCRIPTION
it was clearly not doing something related to its name, and there was missing argument. (`self.signedPreKeyStore.removeSignedPreKey` clearly cannot be called with 0 args)

I guess it must be like I wrote, right?

Also, is it even mandatory to define, if it's not used anywhere?