### PR TITLE
Fix #1090 #1126 #1158

### DIFF
--- a/yowsup/demos/cli/layer.py
+++ b/yowsup/demos/cli/layer.py
@@ -389,6 +389,17 @@ class YowsupCliLayer(Cli, YowInterfaceLayer):
             errorFn = lambda errorEntity, originalEntity: self.onRequestUploadError(jid, path, errorEntity, originalEntity)
 
             self._sendIq(entity, successFn, errorFn)
+
+    @clicmd("Send a video with optional caption")
+    def video_send(self, number, path, caption = None):
+        if self.assertConnected():
+            jid = self.aliasToJid(number)
+            entity = RequestUploadIqProtocolEntity(RequestUploadIqProtocolEntity.MEDIA_TYPE_VIDEO, filePath=path)
+            successFn = lambda successEntity, originalEntity: self.onRequestUploadResult(jid, path, successEntity, originalEntity, caption)
+            errorFn = lambda errorEntity, originalEntity: self.onRequestUploadError(jid, path, errorEntity, originalEntity)
+
+            self._sendIq(entity, successFn, errorFn)
+
     @clicmd("Send typing state")
     def state_typing(self, jid):
         if self.assertConnected():
@@ -522,6 +533,10 @@ class YowsupCliLayer(Cli, YowInterfaceLayer):
         entity = AudioDownloadableMediaMessageProtocolEntity.fromFilePath(filePath, url, ip, to)
         self.toLower(entity)
 
+    def doSendVideo(self, filePath, url, to, ip = None, caption = None):
+        entity = VideoDownloadableMediaMessageProtocolEntity.fromFilePath(filePath, url, ip, to, caption = caption)
+        self.toLower(entity)
+
     def __str__(self):
         return "CLI Interface Layer"
 
@@ -531,8 +546,10 @@ class YowsupCliLayer(Cli, YowInterfaceLayer):
 
         if requestUploadIqProtocolEntity.mediaType == RequestUploadIqProtocolEntity.MEDIA_TYPE_AUDIO:
             doSendFn = self.doSendAudio
-        else:
+        elif requestUploadIqProtocolEntity.mediaType == RequestUploadIqProtocolEntity.MEDIA_TYPE_IMAGE:
             doSendFn = self.doSendImage
+        elif requestUploadIqProtocolEntity.mediaType == RequestUploadIqProtocolEntity.MEDIA_TYPE_VIDEO:
+            doSendFn = self.doSendVideo
 
         if resultRequestUploadIqProtocolEntity.isDuplicate():
             doSendFn(filePath, resultRequestUploadIqProtocolEntity.getUrl(), jid,

--- a/yowsup/layers/protocol_groups/protocolentities/notification_groups.py
+++ b/yowsup/layers/protocol_groups/protocolentities/notification_groups.py
@@ -21,10 +21,10 @@ class GroupsNotificationProtocolEntity(NotificationProtocolEntity):
         return self._participant if full else self._participant.split('@')[0]
 
     def getGroupId(self):
-        return self._id
+        return self.groupId
 
     def setGroupId(self, groupId):
-        self._id = groupId
+        self.groupId = groupId
 
 
     def __str__(self):

--- a/yowsup/layers/protocol_media/protocolentities/message_media_downloadable_video.py
+++ b/yowsup/layers/protocol_media/protocolentities/message_media_downloadable_video.py
@@ -50,7 +50,7 @@ class VideoDownloadableMediaMessageProtocolEntity(DownloadableMediaMessageProtoc
             out += "Caption: %s\n" % self.caption
         return out
 
-    def setVideoProps(self, abitrate, acodec, asampfmt, asampfreq, duration, encoding, fps, width, height, seconds, vbitrate, vcodec, caption  = None):
+    def setVideoProps(self, abitrate = '', acodec = '', asampfmt = '', asampfreq = '', duration = '', encoding = '', fps = '', width = '', height = '', seconds = '', vbitrate = '', vcodec = '', caption = None):
         self.abitrate  = abitrate
         self.acodec    = acodec
         self.asampfmt  = asampfmt
@@ -109,4 +109,11 @@ class VideoDownloadableMediaMessageProtocolEntity(DownloadableMediaMessageProtoc
             mediaNode.getAttributeValue("vcodec"),
             mediaNode.getAttributeValue("caption")
         )
+        return entity
+
+    @staticmethod
+    def fromFilePath(path, url, ip, to, mimeType = None, preview = None, caption = None, dimensions = None):
+        entity = DownloadableMediaMessageProtocolEntity.fromFilePath(path, url, DownloadableMediaMessageProtocolEntity.MEDIA_TYPE_VIDEO, ip, to, mimeType, preview)
+        entity.__class__ = VideoDownloadableMediaMessageProtocolEntity
+        entity.setVideoProps(caption = caption)
         return entity


### PR DESCRIPTION
setGroupId function was setting the _id variable to group JID, avoiding group notifications acks from being sent. What resulted in always receive the same notification again and again each time yowsup was restarted.