### PR TITLE
#1181: Event callback feature implementation. YowInterfaceLayer

### DIFF
--- a/yowsup/demos/cli/layer.py
+++ b/yowsup/demos/cli/layer.py
@@ -1,7 +1,7 @@
 from .cli import Cli, clicmd
-from yowsup.layers.interface import YowInterfaceLayer, ProtocolEntityCallback, EventCallback
+from yowsup.layers.interface import YowInterfaceLayer, ProtocolEntityCallback
 from yowsup.layers.auth import YowAuthenticationProtocolLayer
-from yowsup.layers import YowLayerEvent
+from yowsup.layers import YowLayerEvent, EventCallback
 from yowsup.layers.network import YowNetworkLayer
 import sys
 from yowsup.common import YowConstants

--- a/yowsup/layers/__init__.py
+++ b/yowsup/layers/__init__.py
@@ -203,12 +203,36 @@ class YowLayerTest(unittest.TestCase):
         self.lowerSink = []
         self.toUpper = self.receiveOverrider
         self.toLower = self.sendOverrider
+        self.upperEventSink = []
+        self.lowerEventSink = []
+        self.emitEvent = self.emitEventOverrider
+        self.broadcastEvent = self.broadcastEventOverrider
 
     def receiveOverrider(self, data):
         self.upperSink.append(data)
 
     def sendOverrider(self, data):
         self.lowerSink.append(data)
+        
+    def emitEventOverrider(self, event):
+        self.upperEventSink.append(event)
+    
+    def broadcastEventOverrider(self, event):
+        self.lowerEventSink.append(event)
+        
+    def assert_emitEvent(self, event):
+        self.emitEvent(event)
+        try:
+            self.assertEqual(event, self.upperEventSink.pop())
+        except IndexError:
+            raise AssertionError("Event '%s' was not emited through this layer" % (event.getName()))
+        
+    def assert_broadcastEvent(self, event):
+        self.broadcastEvent(event)
+        try:
+            self.assertEqual(event, self.lowerEventSink.pop())
+        except IndexError:
+            raise AssertionError("Event '%s' was not broadcasted through this layer" % (event.getName()))
 
 class YowProtocolLayerTest(YowLayerTest):
     def assertSent(self, entity):

--- a/yowsup/layers/__init__.py
+++ b/yowsup/layers/__init__.py
@@ -1,4 +1,5 @@
 import unittest
+import inspect
 try:
     import Queue
 except ImportError:
@@ -21,6 +22,14 @@ class YowLayerEvent:
 
     def getArg(self, name):
         return self.args[name] if name in self.args else None
+    
+class EventCallback(object):
+    def __init__(self, eventName):
+        self.eventName = eventName
+
+    def __call__(self, fn):
+        fn.event_callback = self.eventName
+        return fn
 
 
 class YowLayer(object):
@@ -34,6 +43,13 @@ class YowLayer(object):
     def __init__(self):
         self.setLayers(None, None)
         self.interface = None
+        self.event_callbacks = {}
+        members = inspect.getmembers(self, predicate=inspect.ismethod)
+        for m in members:
+            if hasattr(m[1], "event_callback"):
+                fname = m[0]
+                fn = m[1]
+                self.event_callbacks[fn.event_callback] = getattr(self, fname)
 
     def getLayerInterface(self, YowLayerClass = None):
         return self.interface if YowLayerClass is None else self.__stack.getLayerInterface(YowLayerClass)
@@ -82,6 +98,9 @@ class YowLayer(object):
 
     '''return true to stop propagating the event'''
     def onEvent(self, yowLayerEvent):
+        eventName = yowLayerEvent.getName()
+        if eventName in self.event_callbacks:
+            return self.event_callbacks[eventName](yowLayerEvent)
         return False
 
     def getProp(self, key, default = None):

--- a/yowsup/layers/auth/layer_authentication.py
+++ b/yowsup/layers/auth/layer_authentication.py
@@ -1,4 +1,4 @@
-from yowsup.layers import YowLayerEvent, YowProtocolLayer
+from yowsup.layers import YowLayerEvent, YowProtocolLayer, EventCallback
 from .keystream import KeyStream
 from yowsup.common.tools import TimeTools
 from .layer_crypt import YowCryptLayer
@@ -47,10 +47,10 @@ class YowAuthenticationProtocolLayer(YowProtocolLayer):
         else:
             prop = self.getProp(YowAuthenticationProtocolLayer.PROP_CREDENTIALS)
             return prop[0] if prop else None
-
-    def onEvent(self, event):
-        if event.getName() == YowNetworkLayer.EVENT_STATE_CONNECTED:
-            self.login()
+        
+    @EventCallback(YowNetworkLayer.EVENT_STATE_CONNECTED)
+    def onConnected(self, yowLayerEvent):
+        self.login()
 
     ## general methods
     def login(self):

--- a/yowsup/layers/auth/layer_crypt.py
+++ b/yowsup/layers/auth/layer_crypt.py
@@ -1,4 +1,4 @@
-from yowsup.layers import YowLayer
+from yowsup.layers import YowLayer, EventCallback
 from yowsup.layers.network import YowNetworkLayer
 class YowCryptLayer(YowLayer):
     '''
@@ -12,12 +12,14 @@ class YowCryptLayer(YowLayer):
         super(YowCryptLayer, self).__init__()
         self.keys = (None,None)
 
-    def onEvent(self, yowLayerEvent):
-        if yowLayerEvent.getName() == YowNetworkLayer.EVENT_STATE_CONNECTED:
-            self.keys = (None,None)
-        elif yowLayerEvent.getName() == YowCryptLayer.EVENT_KEYS_READY:
-            self.keys = yowLayerEvent.getArg("keys")
-            return True
+    @EventCallback(YowNetworkLayer.EVENT_STATE_CONNECTED)
+    def onConnected(self, yowLayerEvent):
+        self.keys = (None,None)
+    
+    @EventCallback(EVENT_KEYS_READY)
+    def onKeysReady(self, yowLayerEvent):
+        self.keys = yowLayerEvent.getArg("keys")
+        return True
 
     def send(self, data):
         outputKey = self.keys[1]

--- a/yowsup/layers/axolotl/layer.py
+++ b/yowsup/layers/axolotl/layer.py
@@ -1,4 +1,4 @@
-from yowsup.layers import YowProtocolLayer, YowLayerEvent
+from yowsup.layers import YowProtocolLayer, YowLayerEvent, EventCallback
 from .protocolentities import SetKeysIqProtocolEntity
 from axolotl.util.keyhelper import KeyHelper
 from .store.sqlite.liteaxolotlstore import LiteAxolotlStore
@@ -81,26 +81,32 @@ class YowAxolotlLayer(YowProtocolLayer):
         return self.state == self.__class__._STATE_GENKEYS
     ########
 
-    ### standard layer methods ###
-    def onEvent(self, yowLayerEvent):
-        if yowLayerEvent.getName() == self.__class__.EVENT_PREKEYS_SET:
-            self.sendKeys(fresh=False)
-        elif yowLayerEvent.getName() == YowNetworkLayer.EVENT_STATE_CONNECTED:
-            if self.isInitState():
-                self.setProp(YowAuthenticationProtocolLayer.PROP_PASSIVE, True)
-        elif yowLayerEvent.getName() == YowAuthenticationProtocolLayer.EVENT_AUTHED:
-            if yowLayerEvent.getArg("passive") and self.isInitState():
-                logger.info("Axolotl layer is generating keys")
-                self.sendKeys()
-        elif yowLayerEvent.getName() == YowNetworkLayer.EVENT_STATE_DISCONNECTED:
-            if self.isGenKeysState():
-                #we requested this disconnect in this layer to switch off passive
-                #no need to traverse it to upper layers?
-                self.setProp(YowAuthenticationProtocolLayer.PROP_PASSIVE, False)
-                self.state = self.__class__._STATE_HASKEYS
-                self.getLayerInterface(YowNetworkLayer).connect()
-            else:
-                self.store = None
+
+    @EventCallback(EVENT_PREKEYS_SET)
+    def onPreKeysSet(self, yowLayerEvent):
+        self.sendKeys(fresh=False)
+        
+    @EventCallback(YowNetworkLayer.EVENT_STATE_CONNECTED)
+    def onConnected(self, yowLayerEvent):
+        if self.isInitState():
+            self.setProp(YowAuthenticationProtocolLayer.PROP_PASSIVE, True)
+    
+    @EventCallback(YowAuthenticationProtocolLayer.EVENT_AUTHED)
+    def onAuthed(self, yowLayerEvent):
+        if yowLayerEvent.getArg("passive") and self.isInitState():
+            logger.info("Axolotl layer is generating keys")
+            self.sendKeys()
+        
+    @EventCallback(YowNetworkLayer.EVENT_STATE_DISCONNECTED)
+    def onDisconnected(self, yowLayerEvent):
+        if self.isGenKeysState():
+            #we requested this disconnect in this layer to switch off passive
+            #no need to traverse it to upper layers?
+            self.setProp(YowAuthenticationProtocolLayer.PROP_PASSIVE, False)
+            self.state = self.__class__._STATE_HASKEYS
+            self.getLayerInterface(YowNetworkLayer).connect()
+        else:
+            self.store = None
 
     def send(self, node):
         if node.tag == "message" and node["type"] == "text" and node["to"] not in self.skipEncJids:

--- a/yowsup/layers/interface/__init__.py
+++ b/yowsup/layers/interface/__init__.py
@@ -1,1 +1,1 @@
-from .interface import YowInterfaceLayer, ProtocolEntityCallback
+from .interface import YowInterfaceLayer, ProtocolEntityCallback, EventCallback

--- a/yowsup/layers/interface/__init__.py
+++ b/yowsup/layers/interface/__init__.py
@@ -1,1 +1,1 @@
-from .interface import YowInterfaceLayer, ProtocolEntityCallback, EventCallback
+from .interface import YowInterfaceLayer, ProtocolEntityCallback

--- a/yowsup/layers/interface/interface.py
+++ b/yowsup/layers/interface/interface.py
@@ -14,20 +14,12 @@ class ProtocolEntityCallback(object):
         fn.entity_callback = self.entityType
         return fn
     
-class EventCallback(object):
-    def __init__(self, eventName):
-        self.eventName = eventName
-
-    def __call__(self, fn):
-        fn.event_callback = self.eventName
-        return fn
 
 class YowInterfaceLayer(YowLayer):
 
     def __init__(self):
         super(YowInterfaceLayer, self).__init__()
         self.entity_callbacks = {}
-        self.event_callbacks = {}
         self.iqRegistry = {}
         # self.receiptsRegistry = {}
         members = inspect.getmembers(self, predicate=inspect.ismethod)
@@ -36,10 +28,7 @@ class YowInterfaceLayer(YowLayer):
                 fname = m[0]
                 fn = m[1]
                 self.entity_callbacks[fn.entity_callback] = getattr(self, fname)
-            if hasattr(m[1], "event_callback"):
-                fname = m[0]
-                fn = m[1]
-                self.event_callbacks[fn.event_callback] = getattr(self, fname)
+            
 
     def _sendIq(self, iqEntity, onSuccess = None, onError = None):
         assert iqEntity.getTag() == "iq", "Expected *IqProtocolEntity in _sendIq, got %s" % iqEntity.getTag()
@@ -111,13 +100,6 @@ class YowInterfaceLayer(YowLayer):
                 self.entity_callbacks[entityType](entity)
             else:
                 self.toUpper(entity)
-                
-    def onEvent(self, yowLayerEvent):
-        eventName = yowLayerEvent.getName()
-        if eventName in self.event_callbacks:
-            return self.event_callbacks[eventName](yowLayerEvent)
-        return False
-
-
+ 
     def __str__(self):
         return "Interface Layer"

--- a/yowsup/layers/network/layer.py
+++ b/yowsup/layers/network/layer.py
@@ -1,4 +1,4 @@
-from yowsup.layers import YowLayer, YowLayerEvent
+from yowsup.layers import YowLayer, YowLayerEvent, EventCallback
 from yowsup.common.http.httpproxy import HttpProxy
 from yowsup.layers.network.layer_interface import YowNetworkLayerInterface
 import asyncore, socket, logging
@@ -33,14 +33,16 @@ class YowNetworkLayer(YowLayer, asyncore.dispatcher_with_send):
             proxyHandler = httpProxy.handler()
             proxyHandler.onConnect = onConnect
         self.proxyHandler = proxyHandler
-
-    def onEvent(self, ev):
-        if ev.getName() == YowNetworkLayer.EVENT_STATE_CONNECT:
-            self.createConnection()
-            return True
-        elif ev.getName() == YowNetworkLayer.EVENT_STATE_DISCONNECT:
-            self.destroyConnection(ev.getArg("reason"))
-            return True
+        
+    @EventCallback(EVENT_STATE_CONNECT)
+    def onConnect(self, ev):
+        self.createConnection()
+        return True
+    
+    @EventCallback(EVENT_STATE_DISCONNECT)
+    def onDisconnect(self, ev):
+        self.destroyConnection(ev.getArg("reason"))
+        return True        
 
     def createConnection(self):
         self.create_socket(socket.AF_INET, socket.SOCK_STREAM)

--- a/yowsup/layers/network/layer.py
+++ b/yowsup/layers/network/layer.py
@@ -19,9 +19,9 @@ class YowNetworkLayer(YowLayer, asyncore.dispatcher_with_send):
     PROP_NET_READSIZE           = "org.openwhatsapp.yowsup.prop.net.readSize"
 
     def __init__(self):
+        asyncore.dispatcher.__init__(self)
         YowLayer.__init__(self)
         self.interface = YowNetworkLayerInterface(self)
-        asyncore.dispatcher.__init__(self)
         httpProxy = HttpProxy.getFromEnviron()
         proxyHandler = None
         if httpProxy != None:

--- a/yowsup/layers/stanzaregulator/layer.py
+++ b/yowsup/layers/stanzaregulator/layer.py
@@ -1,4 +1,4 @@
-from yowsup.layers import YowLayer, YowLayerEvent
+from yowsup.layers import YowLayer, YowLayerEvent, EventCallback
 from yowsup.layers.network import YowNetworkLayer
 class YowStanzaRegulator(YowLayer):
     '''
@@ -7,17 +7,18 @@ class YowStanzaRegulator(YowLayer):
     '''
 
     def __init__(self):
-        super(YowLayer, self).__init__()
+        super(YowStanzaRegulator, self).__init__()
         self.buf = bytearray()
         self.enabled = False
-
-    def onEvent(self, yowLayerEvent):
-        if yowLayerEvent.getName() == YowNetworkLayer.EVENT_STATE_CONNECTED:
-            self.enabled = True
-            self.buf = bytearray()
-        elif yowLayerEvent.getName() == YowNetworkLayer.EVENT_STATE_DISCONNECTED:
-            self.enabled = False
-
+        
+    @EventCallback(YowNetworkLayer.EVENT_STATE_CONNECTED)
+    def onConnected(self, yowLayerEvent):
+        self.enabled = True
+        self.buf = bytearray()
+    
+    @EventCallback(YowNetworkLayer.EVENT_STATE_DISCONNECTED)
+    def onDisconnected(self, yowLayerEvent):
+        self.enabled = False
 
     def send(self, data):
         self.toLower(data)


### PR DESCRIPTION
As described in #1181 decorator for event callbacks is implemented. Nothing reinvented just following the ProtocolEntity callback scheme for this implementation.
Event callback added to yowsup-cli.

Moreover, I found `YowLayerTest` not enough for testing events. I have added some functionality for `emitEvent` and `broadcastEvent` testing. 

