### PR TITLE
Complete Iq request callbacks for group protocol.

### DIFF
--- a/yowsup/layers/protocol_groups/layer.py
+++ b/yowsup/layers/protocol_groups/layer.py
@@ -1,4 +1,6 @@
 from yowsup.layers import YowLayer, YowLayerEvent, YowProtocolLayer
+from yowsup.layers.protocol_iq.protocolentities import ErrorIqProtocolEntity
+from yowsup.layers.protocol_iq.protocolentities.iq_result import ResultIqProtocolEntity
 from .protocolentities import *
 import logging
 logger = logging.getLogger(__name__)
@@ -60,12 +62,15 @@ class YowGroupsProtocolLayer(YowProtocolLayer):
 
     def onCreateGroupFailed(self, node, originalIqEntity):
         logger.error("Group create failed")
+        self.toUpper(ErrorIqProtocolEntity.fromProtocolTreeNode(node))
 
     def onSetSubjectSuccess(self, node, originalIqEntity):
         logger.info("Group subject change success")
+        self.toUpper(ResultIqProtocolEntity.fromProtocolTreeNode(node))
 
     def onSetSubjectFailed(self, node, originalIqEntity):
         logger.error("Group subject change failed")
+        self.toUpper(ErrorIqProtocolEntity.fromProtocolTreeNode(node))
 
     def onGetParticipantsResult(self, node, originalIqEntity):
         self.toUpper(ListParticipantsResultIqProtocolEntity.fromProtocolTreeNode(node))
@@ -76,6 +81,7 @@ class YowGroupsProtocolLayer(YowProtocolLayer):
 
     def onRemoveParticipantsFailed(self, node, originalIqEntity):
         logger.error("Group remove participants failed")
+        self.toUpper(ErrorIqProtocolEntity.fromProtocolTreeNode(node))
 
     def onRemoveParticipantsSuccess(self, node, originalIqEntity):
         logger.info("Group remove participants success")
@@ -83,15 +89,19 @@ class YowGroupsProtocolLayer(YowProtocolLayer):
 
     def onPromoteParticipantsFailed(self, node, originalIqEntity):
         logger.error("Group promote participants failed")
+        self.toUpper(ErrorIqProtocolEntity.fromProtocolTreeNode(node))
 
     def onPromoteParticipantsSuccess(self, node, originalIqEntity):
         logger.info("Group promote participants success")
+        self.toUpper(ResultIqProtocolEntity.fromProtocolTreeNode(node))
 
     def onDemoteParticipantsFailed(self, node, originalIqEntity):
         logger.error("Group demote participants failed")
+        self.toUpper(ErrorIqProtocolEntity.fromProtocolTreeNode(node))
 
     def onDemoteParticipantsSuccess(self, node, originalIqEntity):
         logger.info("Group demote participants success")
+        self.toUpper(ResultIqProtocolEntity.fromProtocolTreeNode(node))
 
     def onAddParticipantsFailed(self, node, originalIqEntity):
         logger.error("Group add participants failed")
@@ -106,6 +116,7 @@ class YowGroupsProtocolLayer(YowProtocolLayer):
 
     def onLeaveGroupFailed(self, node, originalIqEntity):
         logger.error("Group leave failed")
+        self.toUpper(ErrorIqProtocolEntity.fromProtocolTreeNode(node))
 
     def onInfoGroupSuccess(self, node, originalIqEntity):
         logger.info("Group info success")
@@ -113,6 +124,7 @@ class YowGroupsProtocolLayer(YowProtocolLayer):
 
     def onInfoGroupFailed(self, node, originalIqEntity):
         logger.error("Group info failed")
+        self.toUpper(ErrorIqProtocolEntity.fromProtocolTreeNode(node))
 
     def recvNotification(self, node):
         if node["type"] == "w:gp2":


### PR DESCRIPTION
The group protocol layer appears to be the only remaining layer that
does not call `toUpper()` with an entity for every incoming iq request
node. This will cause two bad things to happen:

  1. Interface clients will not get callbacks for these Iq
     request sequences in certain cases or success/error.
  2. Any attempts to use registered callbacks with these incomplete Iq
     request sequences will be leaked.

There's still a much larger memory management issue in Yowsup, assuming
that I'm correct that there's no periodic sweeping of unanswered
registry callbacks. I've reported more about that in Issue
https://github.com/tgalal/yowsup/issues/1263.