### PR TITLE
Media mime check

### DIFF
--- a/yowsup/common/mime.types
+++ b/yowsup/common/mime.types
@@ -1,0 +1,23 @@
+audio/3gpp	 3gpp
+audio/aac	 aac
+audio/aiff	 aif
+audio/amr	 amr
+audio/mp4	 m4a
+audio/mpeg	 mp3 mp2 mpga mpega
+audio/ogg	 oga ogg opus spx
+audio/qcelp	 qcp
+audio/wav	 wav
+audio/webm	 webm
+audio/x-caf	 caf
+audio/x-ms-wma	 wma
+audio/ogg	 ogg
+image/gif	 gif
+image/jpeg	 jpe jpg jpeg
+image/png	 png
+video/3gpp	 3gp
+video/avi	 avi
+video/mp4	 mp4
+video/mpeg	 m1v mpeg mpa mpg mpe
+video/quicktime	 mov qt
+video/x-flv	 flv
+video/x-ms-asf	 asf asx

--- a/yowsup/common/tools.py
+++ b/yowsup/common/tools.py
@@ -7,6 +7,7 @@ import logging
 import tempfile
 import base64
 import hashlib
+import os.path, mimetypes
 
 logger = logging.getLogger(__name__)
 
@@ -159,3 +160,16 @@ class ImageTools:
             preview = fileObj.read()
             fileObj.close()
         return preview
+
+class MimeTools:
+    MIME_FILE = os.path.join(os.path.dirname(__file__), 'mime.types')
+    mimetypes.init() # Load default mime.types
+    mimetypes.init([MIME_FILE]) # Append whatsapp mime.types
+    decode_hex = codecs.getdecoder("hex_codec")
+
+    @staticmethod
+    def getMIME(filepath):
+        mimeType = mimetypes.guess_type(filepath)[0]
+        if mimeType is None:
+            raise Exception("Unsupported/unrecognized file type for: "+filepath);
+        return mimeType

--- a/yowsup/layers/protocol_media/mediauploader.py
+++ b/yowsup/layers/protocol_media/mediauploader.py
@@ -47,6 +47,8 @@ class MediaUploader(WARequest, threading.Thread):
         try:
             filename = os.path.basename(sourcePath)
             filetype = mimetypes.guess_type(filename)[0]
+            if filetype is None:
+                raise Exception("Unsupported/unrecognized file type for: "+filename);
             filesize = os.path.getsize(sourcePath)
 
             self.sock.connect((self.url, self.port))

--- a/yowsup/layers/protocol_media/mediauploader.py
+++ b/yowsup/layers/protocol_media/mediauploader.py
@@ -1,9 +1,10 @@
 from yowsup.common.http.warequest import WARequest
 from yowsup.common.http.waresponseparser import JSONResponseParser
-import socket, ssl, mimetypes, os, hashlib, sys
+import socket, ssl, os, hashlib, sys
 from time import sleep
 import threading
 import logging
+from yowsup.common.tools import MimeTools
 
 logger = logging.getLogger(__name__)
 
@@ -46,9 +47,7 @@ class MediaUploader(WARequest, threading.Thread):
 
         try:
             filename = os.path.basename(sourcePath)
-            filetype = mimetypes.guess_type(filename)[0]
-            if filetype is None:
-                raise Exception("Unsupported/unrecognized file type for: "+filename);
+            filetype = MimeTools.getMIME(filename)
             filesize = os.path.getsize(sourcePath)
 
             self.sock.connect((self.url, self.port))

--- a/yowsup/layers/protocol_media/protocolentities/message_media_downloadable.py
+++ b/yowsup/layers/protocol_media/protocolentities/message_media_downloadable.py
@@ -1,6 +1,6 @@
 from .message_media import MediaMessageProtocolEntity
 from yowsup.common.tools import WATools
-import mimetypes
+from yowsup.common.tools import MimeTools
 import os
 class DownloadableMediaMessageProtocolEntity(MediaMessageProtocolEntity):
     '''
@@ -83,9 +83,7 @@ class DownloadableMediaMessageProtocolEntity(MediaMessageProtocolEntity):
 
     @staticmethod
     def fromFilePath(fpath, url, mediaType, ip, to, mimeType = None, preview = None, filehash = None, filesize = None):
-        mimeType = mimeType or mimetypes.guess_type(fpath)[0]
-        if mimeType is None:
-            raise Exception("Unsupported/unrecognized file type for: "+fpath);
+        mimeType = mimeType or MimeTools.getMIME(fpath)
         filehash = filehash or WATools.getFileHashForUpload(fpath)
         size = filesize or os.path.getsize(fpath)
         fileName = os.path.basename(fpath)

--- a/yowsup/layers/protocol_media/protocolentities/message_media_downloadable.py
+++ b/yowsup/layers/protocol_media/protocolentities/message_media_downloadable.py
@@ -84,6 +84,8 @@ class DownloadableMediaMessageProtocolEntity(MediaMessageProtocolEntity):
     @staticmethod
     def fromFilePath(fpath, url, mediaType, ip, to, mimeType = None, preview = None, filehash = None, filesize = None):
         mimeType = mimeType or mimetypes.guess_type(fpath)[0]
+        if mimeType is None:
+            raise Exception("Unsupported/unrecognized file type for: "+fpath);
         filehash = filehash or WATools.getFileHashForUpload(fpath)
         size = filesize or os.path.getsize(fpath)
         fileName = os.path.basename(fpath)

--- a/yowsup/structs/protocoltreenode.py
+++ b/yowsup/structs/protocoltreenode.py
@@ -50,6 +50,8 @@ class ProtocolTreeNode(object):
         out = "<"+self.tag
         if self.attributes is not None:
             for key,val in self.attributes.items():
+                if val is None:
+                    raise Exception("None val for key: "+key);
                 out+= " "+key+'="'+val+'"'
         out+= ">\n"
 


### PR DESCRIPTION
MIME type not found is checked to avoid errors like #1054 
A mime.types file is include to be appended to system mime.types

ProtocolTreeNode generates a descriptive exception when None value is recieved in an attribute.