### PR TITLE
Fixed #1464: mime_types included into egg

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include yowsup/common/mime.types

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
     #long_description=long_description,
     packages= find_packages(),
     include_package_data=True,
+    data_files = [('yowsup/common', ['yowsup/common/mime.types'])],
     platforms='any',
     #test_suite='',
     classifiers = [

--- a/yowsup/common/tools.py
+++ b/yowsup/common/tools.py
@@ -9,6 +9,7 @@ import base64
 import hashlib
 import os.path, mimetypes
 from .optionalmodules import PILOptionalModule, FFVideoOptionalModule
+from pkg_resources import resource_string
 
 logger = logging.getLogger(__name__)
 
@@ -150,10 +151,9 @@ class ImageTools:
         return preview
 
 class MimeTools:
-    MIME_FILE = os.path.join(os.path.dirname(__file__), 'mime.types')
+    MIME_FILE = resource_string(__name__, 'mime.types')
     mimetypes.init() # Load default mime.types
     mimetypes.init([MIME_FILE]) # Append whatsapp mime.types
-    decode_hex = codecs.getdecoder("hex_codec")
 
     @staticmethod
     def getMIME(filepath):


### PR DESCRIPTION
Fixed by:
 - included mime.types into egg
-  Used pkg_resources for data resource reading

Additionally, removed incorrectly copied and unnecesary line.