### PR TITLE
add files sending capabilities

### DIFF
--- a/yowsup-cli
+++ b/yowsup-cli
@@ -329,9 +329,7 @@ class DemosArgParser(YowArgParser):
         self.justSendMessage(recipient, filecontent)
 
     def startSendClient(self):
-        self.justSendMessage(args["send"][0], self.args["send"][1])
-        stack.start()
-
+        self.justSendMessage(self.args["send"][0], self.args["send"][1])
 
     def justSendMessage(self, recipient, message):
         from yowsup.demos import sendclient
@@ -342,8 +340,7 @@ class DemosArgParser(YowArgParser):
 
         try:
             self.printInfoText()
-            stack = sendclient.YowsupSendStack(credentials, [([recipient, client])],
-                                               not self.args["unmoxie"])
+            stack = sendclient.YowsupSendStack(credentials, [([recipient, message])], not self.args["unmoxie"])
             stack.start()
         except KeyboardInterrupt:
             print("\nYowsdown")

--- a/yowsup-cli
+++ b/yowsup-cli
@@ -340,7 +340,7 @@ class DemosArgParser(YowArgParser):
 
         try:
             self.printInfoText()
-            stack = sendclient.YowsupSendStack(credentials, [([recipient, message])], not self.args["unmoxie"])
+            stack = sendclient.YowsupSendStack(credentials, [([recipient, message.encode("utf-8")])], not self.args["unmoxie"])
             stack.start()
         except KeyboardInterrupt:
             print("\nYowsdown")

--- a/yowsup-cli
+++ b/yowsup-cli
@@ -248,6 +248,12 @@ class DemosArgParser(YowArgParser):
         cmdopts = self.add_argument_group("Command line interface demo")
         cmdopts.add_argument('-y', '--yowsup', action = "store_true", help = "Start the Yowsup command line client")
 
+         fileOpts = self.add_argument_group("SendFile client demo")
+         fileOpts.add_argument('-f', '--file', action="store", help = "Send a file to a specified phone number, "
+                                                                      "wait for server receipt and exit",
+                               metavar=("phone", "filename"), nargs = 2)
+
+
         echoOpts = self.add_argument_group("Echo client demo")
         echoOpts.add_argument('-e', '--echo', action = "store_true", help = "Start the Yowsup Echo client")
 
@@ -270,6 +276,8 @@ class DemosArgParser(YowArgParser):
             self.startEcho()
         elif self.args["send"]:
             self.startSendClient()
+        elif self.args["file"]:
+            self.startSendFileClient()
         elif self.args["sync"]:
             self.startSyncContacts()
         else:
@@ -310,7 +318,22 @@ class DemosArgParser(YowArgParser):
             print("\nYowsdown")
             sys.exit(0)
 
+    def startSendFileClient(self):
+        filename = self.args["file"][1]
+        from os.path import isfile
+        if not isfile(filename):
+           print ("Error: filename {} does not exists".format(filename))
+           sys.exit(1)
+        filecontent = open(filename).read()
+        recipient = self.args["file"][0]
+        self.justSendMessage(recipient, filecontent)
+
     def startSendClient(self):
+        self.justSendMessage(args["send"][0], self.args["send"][1])
+        stack.start()
+
+
+    def justSendMessage(self, recipient, message)
         from yowsup.demos import sendclient
         credentials = self._getCredentials()
         if not credentials:
@@ -319,7 +342,7 @@ class DemosArgParser(YowArgParser):
 
         try:
             self.printInfoText()
-            stack = sendclient.YowsupSendStack(credentials, [([self.args["send"][0], self.args["send"][1]])],
+            stack = sendclient.YowsupSendStack(credentials, [([recipient, client])],
                                                not self.args["unmoxie"])
             stack.start()
         except KeyboardInterrupt:

--- a/yowsup-cli
+++ b/yowsup-cli
@@ -248,8 +248,8 @@ class DemosArgParser(YowArgParser):
         cmdopts = self.add_argument_group("Command line interface demo")
         cmdopts.add_argument('-y', '--yowsup', action = "store_true", help = "Start the Yowsup command line client")
 
-         fileOpts = self.add_argument_group("SendFile client demo")
-         fileOpts.add_argument('-f', '--file', action="store", help = "Send a file to a specified phone number, "
+        fileOpts = self.add_argument_group("SendFile client demo")
+        fileOpts.add_argument('-f', '--file', action="store", help = "Send a file to a specified phone number, "
                                                                       "wait for server receipt and exit",
                                metavar=("phone", "filename"), nargs = 2)
 
@@ -333,7 +333,7 @@ class DemosArgParser(YowArgParser):
         stack.start()
 
 
-    def justSendMessage(self, recipient, message)
+    def justSendMessage(self, recipient, message):
         from yowsup.demos import sendclient
         credentials = self._getCredentials()
         if not credentials:


### PR DESCRIPTION
currently yowsup-cli only supports sending one liners.
this small addition adds sending files (multiline) messages
it is convenient tool in integrating yowsup in robots. 