### PR TITLE
Fixed #1578

### DIFF
--- a/yowsup/common/tools.py
+++ b/yowsup/common/tools.py
@@ -152,8 +152,10 @@ class ImageTools:
 class MimeTools:
     MIME_FILE = os.path.join(os.path.dirname(__file__), 'mime.types')
     mimetypes.init() # Load default mime.types
-    mimetypes.init([MIME_FILE]) # Append whatsapp mime.types
-    decode_hex = codecs.getdecoder("hex_codec")
+    try:
+        mimetypes.init([MIME_FILE]) # Append whatsapp mime.types
+    except exception as e:
+        logger.warning("Mime types supported can't be read. System mimes will be used. Cause: " + e.message)
 
     @staticmethod
     def getMIME(filepath):


### PR DESCRIPTION
Avoid exception (just reported) in Windows due to too long path. So system mime.types will be used.