### PR TITLE
changed default env to android

### DIFF
--- a/yowsup/env/env.py
+++ b/yowsup/env/env.py
@@ -4,7 +4,7 @@ from six import with_metaclass
 
 logger = logging.getLogger(__name__)
 
-DEFAULT = "s40"
+DEFAULT = "android"
 
 class YowsupEnvType(abc.ABCMeta):
     def __init__(cls, name, bases, dct):


### PR DESCRIPTION
"s40" doesn't seem to work anymore (at least for me)
may be related to this: https://blog.whatsapp.com/10000617/WhatsApp-support-for-mobile-devices
so better sooner than later switch to android as default