### PR TITLE
typo fix

### DIFF
--- a/yowsup/layers/axolotl/layer_receive.py
+++ b/yowsup/layers/axolotl/layer_receive.py
@@ -249,7 +249,7 @@ class AxolotlReceivelayer(AxolotlBaseLayer):
         messageNode["type"] = "media"
         mediaNode = ProtocolTreeNode("media", {
             "latitude": locationMessage.degrees_latitude,
-            "longitude": locationMessage.degress_longitude,
+            "longitude": locationMessage.degrees_longitude,
             "name": "%s %s" % (locationMessage.name, locationMessage.address),
             "url": locationMessage.url,
             "encoding": "raw",


### PR DESCRIPTION
fix this typo

`dist-packages/yowsup2-2.5.0-py2.7.egg/yowsup/layers/axolotl/layer_receive.py", line 252, in handleLocationMessage "longitude": locationMessage.degress_longitude, AttributeError: 'LocationMessage' object has no attribute 'degress_longitude'`
