### PR TITLE
Decrypt images

### DIFF
--- a/yowsup/layers/axolotl/layer_receive.py
+++ b/yowsup/layers/axolotl/layer_receive.py
@@ -230,7 +230,8 @@ class AxolotlReceivelayer(AxolotlBaseLayer):
             "caption": imageMessage.caption,
             "encoding": "raw",
             "file": "enc",
-            "ip": "0"
+            "ip": "0",
+            "mediakey": imageMessage.media_key
         }, data = imageMessage.jpeg_thumbnail)
         messageNode.addChild(mediaNode)
 

--- a/yowsup/layers/protocol_media/protocolentities/message_media_downloadable.py
+++ b/yowsup/layers/protocol_media/protocolentities/message_media_downloadable.py
@@ -2,6 +2,15 @@ from .message_media import MediaMessageProtocolEntity
 from yowsup.common.tools import WATools
 from yowsup.common.tools import MimeTools
 import os
+from Crypto.Cipher import AES
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
+from axolotl.kdf.hkdfv3 import HKDFv3
+from axolotl.util.byteutil import ByteUtil
+import binascii
+import base64
 class DownloadableMediaMessageProtocolEntity(MediaMessageProtocolEntity):
     '''
     <message t="{{TIME_STAMP}}" from="{{CONTACT_JID}}"
@@ -35,6 +44,25 @@ class DownloadableMediaMessageProtocolEntity(MediaMessageProtocolEntity):
         out += "File Size: %s\n" % self.size
         out += "File name: %s\n" % self.fileName
         return out
+
+    def decrypt(self, encimg, refkey):
+        derivative = HKDFv3().deriveSecrets(refkey, binascii.unhexlify(self.cryptKeys), 112)
+        parts = ByteUtil.split(derivative, 16, 32)
+        iv = parts[0]
+        cipherKey = parts[1]
+        e_img = encimg[:-10]
+        AES.key_size=128
+        cr_obj = AES.new(key=cipherKey,mode=AES.MODE_CBC,IV=iv)
+        return cr_obj.decrypt(e_img)
+
+    def isEncrypted(self):
+        return self.cryptKeys and self.mediaKey
+
+    def getMediaContent(self):
+        data = urlopen(self.url).read()
+        if self.isEncrypted():
+            data = self.decrypt(data, self.mediaKey)
+        return bytearray(data)
 
     def getMediaSize(self):
         return self.size

--- a/yowsup/layers/protocol_media/protocolentities/message_media_downloadable_image.py
+++ b/yowsup/layers/protocol_media/protocolentities/message_media_downloadable_image.py
@@ -50,6 +50,7 @@ class ImageDownloadableMediaMessageProtocolEntity(DownloadableMediaMessageProtoc
         self.width      = int(width)
         self.height     = int(height)
         self.caption    = caption
+        self.cryptKeys  = '576861747341707020496d616765204b657973'
 
     def getCaption(self):
         return self.caption


### PR DESCRIPTION
I needed working image decryption for my [photo frame project](https://github.com/jbollacke/whatsapp-photo-frame). So I simply cherry-picked the work from Jose Luis Guardiola in jlguardis fork to yowsup2.5: https://github.com/jlguardi/yowsup/commit/230010269f89fd8f7cec653cbd449cd6ecf4b5de
https://github.com/jlguardi/yowsup/commit/ded4d80a21a3956302b8b1c294d78a0f459c36ec

I didn't put any effort/thoughts into the design of the solution. For example one might argue that the downloading code should not be in the DownloadableMediaMessageProtocolEntity.

I don't know where that hardcoded key is really coming from. But it works and I don't feel like investigating  any further.
