### PR TITLE
Fixed typo

### DIFF
--- a/yowsup/layers/axolotl/layer_receive.py
+++ b/yowsup/layers/axolotl/layer_receive.py
@@ -249,7 +249,7 @@ class AxolotlReceivelayer(AxolotlBaseLayer):
         messageNode["type"] = "media"
         mediaNode = ProtocolTreeNode("media", {
             "latitude": locationMessage.degrees_latitude,
-            "longitude": locationMessage.degress_longitude,
+            "longitude": locationMessage.degrees_longitude,
             "name": "%s %s" % (locationMessage.name, locationMessage.address),
             "url": locationMessage.url,
             "encoding": "raw",


### PR DESCRIPTION
When receiving a location, you get the following error:

AttributeError: 'LocationMessage' object has no attribute 'degress_longitude'

Fixed because there was a typo, 'degress_longitude'  instead of 'degrees_longitude'