### PR TITLE
fix Exception when OwnJid is missing in jids

### DIFF
--- a/yowsup/layers/axolotl/layer_send.py
+++ b/yowsup/layers/axolotl/layer_send.py
@@ -212,7 +212,8 @@ class AxolotlSendLayer(AxolotlBaseLayer):
         def sendToGroup(resultNode, requestEntity):
             groupInfo = InfoGroupsResultIqProtocolEntity.fromProtocolTreeNode(resultNode)
             jids = list(groupInfo.getParticipants().keys()) #keys in py3 returns dict_keys
-            jids.remove(ownJid)
+            if ownJid in jids:
+                jids.remove(ownJid)
             return self.ensureSessionsAndSendToGroup(node, jids)
 
         if senderKeyRecord.isEmpty():


### PR DESCRIPTION
it was throwing exception on send message to group.
So I did put check before remove from jids, Don't know if this is correct fix.

Env: Windows Server 2008 R2, python-2.7.9, VCForPython27 etc.