### PR TITLE
Configurable dont crash on unhandled

### DIFF
--- a/yowsup/common/constants.py
+++ b/yowsup/common/constants.py
@@ -26,3 +26,5 @@ class YowConstants:
 
     PREVIEW_WIDTH = 64
     PREVIEW_HEIGHT = 64
+
+    DONT_CRASH_ON_UNHANDLED = False

--- a/yowsup/common/constants.py
+++ b/yowsup/common/constants.py
@@ -26,5 +26,3 @@ class YowConstants:
 
     PREVIEW_WIDTH = 64
     PREVIEW_HEIGHT = 64
-
-    DONT_CRASH_ON_UNHANDLED = False

--- a/yowsup/layers/axolotl/layer_receive.py
+++ b/yowsup/layers/axolotl/layer_receive.py
@@ -1,5 +1,6 @@
 from .layer_base import AxolotlBaseLayer
 
+from yowsup.common import YowConstants
 from yowsup.layers.protocol_receipts.protocolentities import OutgoingReceiptProtocolEntity
 from yowsup.layers.protocol_messages.proto.wa_pb2 import *
 from yowsup.layers.axolotl.protocolentities import *
@@ -200,8 +201,11 @@ class AxolotlReceivelayer(AxolotlBaseLayer):
             self.handleImageMessage(node, m.image_message)
 
         if not handled:
-            print(m)
-            raise ValueError("Unhandled")
+            if YowConstants.DONT_CRASH_ON_UNHANDLED:
+                logger.warning("Unhandled message")
+            else:
+                print(m)
+                raise ValueError("Unhandled")
 
     def handleSenderKeyDistributionMessage(self, senderKeyDistributionMessage, axolotlAddress):
         groupId = senderKeyDistributionMessage.groupId

--- a/yowsup/layers/axolotl/layer_receive.py
+++ b/yowsup/layers/axolotl/layer_receive.py
@@ -1,11 +1,11 @@
 from .layer_base import AxolotlBaseLayer
 
-from yowsup.common import YowConstants
 from yowsup.layers.protocol_receipts.protocolentities import OutgoingReceiptProtocolEntity
 from yowsup.layers.protocol_messages.proto.wa_pb2 import *
 from yowsup.layers.axolotl.protocolentities import *
 from yowsup.structs import ProtocolTreeNode
 from yowsup.layers.axolotl.props import PROP_IDENTITY_AUTOTRUST
+from yowsup.layers.axolotl.props import PROP_IGNORE_UNHANDLED
 
 from axolotl.protocol.prekeywhispermessage import PreKeyWhisperMessage
 from axolotl.protocol.whispermessage import WhisperMessage
@@ -201,8 +201,9 @@ class AxolotlReceivelayer(AxolotlBaseLayer):
             self.handleImageMessage(node, m.image_message)
 
         if not handled:
-            if YowConstants.DONT_CRASH_ON_UNHANDLED:
-                logger.warning("Unhandled message")
+            if PROP_IGNORE_UNHANDLED:
+                self.toLower(OutgoingReceiptProtocolEntity(node["id"], node["from"], participant=node["participant"]).toProtocolTreeNode())
+                logger.warning("Unhandled message, sending delivery receipt")
             else:
                 print(m)
                 raise ValueError("Unhandled")

--- a/yowsup/layers/axolotl/props.py
+++ b/yowsup/layers/axolotl/props.py
@@ -1,1 +1,2 @@
 PROP_IDENTITY_AUTOTRUST =  "org.openwhatsapp.yowsup.prop.axolotl.INDENTITY_AUTOTRUST"
+PROP_IGNORE_UNHANDLED = True


### PR DESCRIPTION
Correct location of prop (yowsup.layers.axolotl.props import PROP_IGNORE_UNHANDLED)
Send delivery receipt

I left the property set to True, although it may not be the best since it changes the previous behavior. What do you think