### PR TITLE
Added onPresenceChange callback

### DIFF
--- a/yowsup/demos/cli/layer.py
+++ b/yowsup/demos/cli/layer.py
@@ -6,6 +6,7 @@ from yowsup.layers.network import YowNetworkLayer
 import sys
 from yowsup.common import YowConstants
 import datetime
+import time
 import os
 import logging
 from yowsup.layers.protocol_groups.protocolentities      import *
@@ -453,8 +454,13 @@ class YowsupCliLayer(Cli, YowInterfaceLayer):
     def onPresenceChange(self, entity):
         status="offline"
         if entity.getType() is None:
-            status="online"            
-        self.output("%s %s %s lastseen %s seconds ago" % (entity.getFrom(), entity.getTag(), status, entity.getLast()))
+            status="online"     
+        ##raw fix for iphone lastseen deny output
+        lastseen = entity.getLast()
+        if status is "offline" and lastseen is "deny":
+            lastseen = time.time()
+        ##
+        self.output("%s %s %s lastseen %s seconds ago" % (entity.getFrom(), entity.getTag(), status, lastseen))
         
     @ProtocolEntityCallback("chatstate")
     def onChatstate(self, entity):

--- a/yowsup/demos/cli/layer.py
+++ b/yowsup/demos/cli/layer.py
@@ -453,13 +453,8 @@ class YowsupCliLayer(Cli, YowInterfaceLayer):
     def onPresenceChange(self, entity):
         status="offline"
         if entity.getType() is None:
-            status="online"
-            
-        ltime,formattedDate=entity.getLast(),"none"
-        if ltime is not None:   
-            formattedDate = datetime.datetime.fromtimestamp(float(ltime)).strftime('%d-%m-%Y %H:%M.%S')
-            
-        self.output("%s %s - lastseen %s - from %s" % (entity.getTag(), status, formattedDate, entity.getFrom()))
+            status="online"            
+        self.output("%s %s %s lastseen %s seconds ago" % (entity.getFrom(), entity.getTag(), status, entity.getLast()))
         
     @ProtocolEntityCallback("chatstate")
     def onChatstate(self, entity):

--- a/yowsup/demos/cli/layer.py
+++ b/yowsup/demos/cli/layer.py
@@ -448,7 +448,13 @@ class YowsupCliLayer(Cli, YowInterfaceLayer):
         return self.L()
 
     ######## receive #########
-
+    
+    @ProtocolEntityCallback("presence")
+    def onPresenceChange(self, entity):
+        print "TEST PRESENCE"
+        print(entity)
+        print "END OF TEST PRESENCE"
+        
     @ProtocolEntityCallback("chatstate")
     def onChatstate(self, entity):
         print(entity)

--- a/yowsup/demos/cli/layer.py
+++ b/yowsup/demos/cli/layer.py
@@ -451,9 +451,15 @@ class YowsupCliLayer(Cli, YowInterfaceLayer):
     
     @ProtocolEntityCallback("presence")
     def onPresenceChange(self, entity):
-        print "TEST PRESENCE"
-        print(entity)
-        print "END OF TEST PRESENCE"
+        status="offline"
+        if entity.getType() is None:
+            status="online"
+            
+        ltime,formattedDate=entity.getLast(),"none"
+        if ltime is not None:   
+            formattedDate = datetime.datetime.fromtimestamp(float(ltime)).strftime('%d-%m-%Y %H:%M.%S')
+            
+        self.output("%s %s - lastseen %s - from %s" % (entity.getTag(), status, formattedDate, entity.getFrom()))
         
     @ProtocolEntityCallback("chatstate")
     def onChatstate(self, entity):


### PR DESCRIPTION
This method is fired when whatsapp monitoring User state change to online/offline.

The output is a string with the **user jid**, the **state** and the **lastseen** tags.
**State** can be online or offline.
**Lastseen** is in seconds and is comparable to `time.time()` output. This means that can be converted to a correct timestamp string with `datetime` class.

The difference between this lastseen an the cli command `/contact lastseen` is that the first return a correct timestamp date the other no! (someone should investigate on this weird thing).

Use on the cli with:
```
/presence available
/contacts sync <phone_number>
/presence subscribe <phone_number>
```
_I noticed that lastseen from that routine works only with android targets. With an IPhone target it returns **deny** ........this need and indeep investigation because i don't know how it works. 
I kindly look for a @tgalal reply on this :)_ 

That's all!
