### PR TITLE
Fix compatibility with six >= 1.11

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ import yowsup
 import platform
 import sys
 
-deps = ['python-dateutil', 'argparse', 'python-axolotl>=0.1.39', 'six==1.10']
+deps = ['python-dateutil', 'argparse', 'python-axolotl>=0.1.39', 'six']
 
 if sys.version_info < (2,7):
     deps += ['importlib', "protobuf==3.4.0"]

--- a/yowsup/env/env.py
+++ b/yowsup/env/env.py
@@ -13,7 +13,6 @@ class YowsupEnvType(abc.ABCMeta):
         super(YowsupEnvType, cls).__init__(name, bases, dct)
 
 class YowsupEnv(with_metaclass(YowsupEnvType, object)):
-    __metaclass__ = YowsupEnvType
     __ENVS = {}
     __CURR = None
 


### PR DESCRIPTION
It seems the fix is removing the ```__metaclass__``` keyword when ```with_metaclass``` is used
as it is pointed at https://github.com/benjaminp/six/issues/210#issuecomment-330154680

This fixes https://github.com/tgalal/yowsup/issues/2259