### PR TITLE
Create socket in YowNetworkLayer with socket.create_connection

### DIFF
--- a/yowsup/layers/network/layer.py
+++ b/yowsup/layers/network/layer.py
@@ -52,9 +52,15 @@ class YowNetworkLayer(YowLayer, asyncore.dispatcher_with_send):
 
     def createConnection(self):
         self.state = self.__class__.STATE_CONNECTING
-        self.create_socket(socket.AF_INET, socket.SOCK_STREAM)
-        self.out_buffer = bytearray()
+
         endpoint = self.getProp(self.__class__.PROP_ENDPOINT)
+
+        sock = socket.create_connection(endpoint)
+        sock.setblocking(0)
+        self.set_socket(sock)
+
+        self.out_buffer = bytearray()
+
         logger.debug("Connecting to %s:%s" % endpoint)
         if self.proxyHandler != None:
             logger.debug("HttpProxy connect: %s:%d" % endpoint)


### PR DESCRIPTION
Came across a problem with `yowsup` in an IPv6 network. Currently, `AF_INET` socket is always created during connection to WhatsApp endpoints, and it fails to connect to non-IPv4 addresses. However, `socket` module has a convenience function `create_connection` that creates and connects a socket to a given address. It handles detection of address family and socket type itself, thus creating a suitable socket both in IPv4 and IPv6 environments.