### PR TITLE
docs: fix simple typo, participat -> participant

### DIFF
--- a/yowsup/layers/axolotl/layer_send.py
+++ b/yowsup/layers/axolotl/layer_send.py
@@ -223,7 +223,7 @@ class AxolotlSendLayer(AxolotlBaseLayer):
 
         received retry for a participant
             - request participants keys
-            - send message with dist key only + conversation, only for this participat
+            - send message with dist key only + conversation, only for this participant
         """
         logger.debug("sendToGroup(node=[omitted], retryReceiptEntity=[%s])" %
                      ("[retry_count=%s, retry_jid=%s]" % (


### PR DESCRIPTION
There is a small typo in yowsup/layers/axolotl/layer_send.py.

Should read `participant` rather than `participat`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md