### PR TITLE
require argparse only for older Python

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,11 @@ import yowsup
 import platform
 import sys
 
-deps = ['consonance==0.1.5', 'argparse', 'python-axolotl==0.2.2', 'six==1.10', 'appdirs', 'protobuf>=3.6.0']
+deps = ['consonance==0.1.5', 'python-axolotl==0.2.2', 'six==1.10', 'appdirs', 'protobuf>=3.6.0']
 
 if sys.version_info < (2, 7):
     deps.append('importlib')
+    deps.append('argparse')
 
 if platform.system().lower() == "windows":
     deps.append('pyreadline')


### PR DESCRIPTION
As of Python >= 2.7 and >= 3.2, the argparse module is maintained within the Python standard library.