### PR TITLE
[doc] fix typos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -372,7 +372,7 @@ example by triggering connect in a bg thread.
 
 ### Changed
 
-- As of January 2015, Yowsup is GPLv3 licensed (previouly was MIT)
+- As of January 2015, Yowsup is GPLv3 licensed (previously was MIT)
 - Fixed broadcast
 - Fixed registration no_routes error
 - Updated registration token
@@ -382,7 +382,7 @@ example by triggering connect in a bg thread.
 - Experimental Axolotl support (end-to-end encryption)
 - Upload and send images
 - Initial support for groups v2
-- Easy switch/ add new enviornment (S40/Android ..etc)
+- Easy switch/ add new environment (S40/Android ..etc)
 - _sendIq in YowProtocolLayer and YowInterfaceLayer with callbacks for Iq result and error
 - new send and exit demo
 - E2E encryption in yowsup and echo client demos

--- a/yowsup-cli
+++ b/yowsup-cli
@@ -121,7 +121,7 @@ class YowArgParser(argparse.ArgumentParser):
                 '--config-phone', '--phone',
                 action="store",
                 help="Your full phone number including the country code you defined in 'cc',"
-                     " without preceeding '+' or '00'"
+                     " without preceding '+' or '00'"
             )
             config_group.add_argument(
                 '--config-cc', '--cc',

--- a/yowsup/demos/sendclient/layer.py
+++ b/yowsup/demos/sendclient/layer.py
@@ -22,7 +22,7 @@ class SendLayer(YowInterfaceLayer):
     def onSuccess(self, successProtocolEntity):
         self.lock.acquire()
         for target in self.getProp(self.__class__.PROP_MESSAGES, []):
-            #getProp() is trying to retreive the list of (jid, message) tuples, if none exist, use the default []
+            #getProp() is trying to retrieve the list of (jid, message) tuples, if none exist, use the default []
             phone, message = target
             messageEntity = TextMessageProtocolEntity(message, to = Jid.normalize(phone))
             #append the id of message to ackQueue list

--- a/yowsup/layers/__init__.py
+++ b/yowsup/layers/__init__.py
@@ -250,7 +250,7 @@ class YowLayerTest(unittest.TestCase):
         try:
             self.assertEqual(event, self.upperEventSink.pop())
         except IndexError:
-            raise AssertionError("Event '%s' was not emited through this layer" % (event.getName()))
+            raise AssertionError("Event '%s' was not emitted through this layer" % (event.getName()))
         
     def assert_broadcastEvent(self, event):
         self.broadcastEvent(event)

--- a/yowsup/layers/axolotl/protocolentities/message_encrypted.py
+++ b/yowsup/layers/axolotl/protocolentities/message_encrypted.py
@@ -16,7 +16,7 @@ HEX:33089eb3c90312210510e0196be72fe65913c6a84e75a54f40a3ee290574d6a23f408df990e7
 
     def setEncEntities(self, encEntities = None):
         assert type(encEntities) is list and len(encEntities) \
-            , "Must have at least a list of minumum 1 enc entity"
+            , "Must have at least a list of minimum 1 enc entity"
         self.encEntities = encEntities
 
     def getEnc(self, encType):

--- a/yowsup/layers/protocol_media/mediauploader.py
+++ b/yowsup/layers/protocol_media/mediauploader.py
@@ -144,6 +144,6 @@ class MediaUploader(WARequest, threading.Thread):
                     self.errorCallback(sourcePath, self.jid, uploadUrl)
 
         except:
-            logger.exception("Error occured at transfer %s" % sys.exc_info()[1])
+            logger.exception("Error occurred at transfer %s" % sys.exc_info()[1])
             if self.errorCallback:
                 self.errorCallback(sourcePath, self.jid, uploadUrl)

--- a/yowsup/layers/protocol_messages/layer.py
+++ b/yowsup/layers/protocol_messages/layer.py
@@ -23,7 +23,7 @@ class YowMessagesProtocolLayer(YowProtocolLayer):
         if entity.getType() == "text":
             self.entityToLower(entity)
 
-    ###recieved node handlers handlers
+    ###received node handlers handlers
     def recvMessageStanza(self, node):
         protoNode = node.getChild("proto")
 


### PR DESCRIPTION
Found via `codespell -S .tox,.mypy_cache -L keypair,addrees`