### PR TITLE
fix(sec): upgrade cryptography to 39.0.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 appdirs==1.4.4
 cffi==1.15.0
 consonance==0.1.5
-cryptography==36.0.0
+cryptography==39.0.1
 dissononce==0.34.3
 protobuf==4.0.0rc2
 pycparser==2.21


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in cryptography 36.0.0
- [CVE-2023-23931](https://www.oscs1024.com/hd/CVE-2023-23931)


### What did I do？
Upgrade cryptography from 36.0.0 to 39.0.1 for vulnerability fix

### What did you expect to happen？
Ideally, no insecure libs should be used.

### How can we automate the detection of these types of issues?
By using the [GitHub Actions](https://github.com/murphysecurity/actions) configurations provided by murphysec, we can conduct automatic code security checks in our CI pipeline.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS